### PR TITLE
feat: make Reply generic over message type

### DIFF
--- a/build/license.json
+++ b/build/license.json
@@ -10,7 +10,7 @@
     "**/Dockerfile",
     "**/*.md",
     "**/*.yml",
-    "samples/*/lib/generated",
+    "samples/*/*/lib/generated",
     "sdk/test/*.desc",
     "tck/generated"
   ],

--- a/samples/ts/ts-eventsourced-shopping-cart/src/shoppingcart.ts
+++ b/samples/ts/ts-eventsourced-shopping-cart/src/shoppingcart.ts
@@ -14,21 +14,21 @@
  * limitations under the License.
  */
 
-import {
-  EventSourcedEntity,
-  replies
-} from "@kalix-io/kalix-javascript-sdk";
+import { EventSourcedEntity, Reply } from "@kalix-io/kalix-javascript-sdk";
 import * as proto from "../lib/generated/proto";
 
 type Context = EventSourcedEntity.EventSourcedEntityCommandContext;
 
 type State = proto.com.example.shoppingcart.domain.Cart;
 
+type Cart = proto.com.example.shoppingcart.Cart;
 type AddLineItem = proto.com.example.shoppingcart.AddLineItem;
 type RemoveLineItem = proto.com.example.shoppingcart.RemoveLineItem;
 type GetShoppingCart = proto.com.example.shoppingcart.GetShoppingCart;
 type ItemAdded = proto.com.example.shoppingcart.domain.ItemAdded;
 type ItemRemoved = proto.com.example.shoppingcart.domain.ItemRemoved;
+
+type Empty = proto.google.protobuf.Empty;
 
 /**
  * Type definitions.
@@ -104,11 +104,11 @@ function addItem(
   addItem: AddLineItem,
   cart: State,
   ctx: Context
-): replies.Reply {
+): Reply<Empty> {
   // Validation:
   // Make sure that it is not possible to add negative quantities
   if (addItem.quantity < 1) {
-    return replies.failure(
+    return Reply.failure(
       "Quantity for item " + addItem.productId + " must be greater than zero."
     );
   }
@@ -123,7 +123,7 @@ function addItem(
   });
   // Emit the event.
   ctx.emit(itemAdded);
-  return replies.message({});
+  return Reply.empty();
 }
 
 /**
@@ -133,7 +133,7 @@ function removeItem(
   removeItem: RemoveLineItem,
   cart: State,
   ctx: Context
-): replies.Reply {
+): Reply<Empty> {
   // Validation:
   // Check that the item that we're removing actually exists.
   const existing = cart.items.find(item => {
@@ -142,7 +142,7 @@ function removeItem(
 
   // If not, fail the command.
   if (!existing) {
-    return replies.failure("Item " + removeItem.productId + " not in cart");
+    return Reply.failure("Item " + removeItem.productId + " not in cart");
   }
 
   // Otherwise, emit an item removed event.
@@ -150,15 +150,15 @@ function removeItem(
     productId: removeItem.productId
   });
   ctx.emit(itemRemoved);
-  return replies.message({});
+  return Reply.empty();
 }
 
 /**
  * Handler for get cart commands.
  */
-function getCart(request: GetShoppingCart, cart: State): replies.Reply {
+function getCart(request: GetShoppingCart, cart: State): Reply<Cart> {
   // Simply return the shopping cart as is.
-  return replies.message(cart);
+  return Reply.message(cart);
 }
 
 /**

--- a/samples/ts/ts-eventsourced-shopping-cart/test/testkit.ts
+++ b/samples/ts/ts-eventsourced-shopping-cart/test/testkit.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Metadata,
-  EventSourcedEntity
-} from "@kalix-io/kalix-javascript-sdk";
+import { Metadata, EventSourcedEntity } from "@kalix-io/kalix-javascript-sdk";
 
 /**
  * Mocks the behaviour of a single Kalix EventSourcedEntity.

--- a/samples/ts/ts-valueentity-counter/src/counter.ts
+++ b/samples/ts/ts-valueentity-counter/src/counter.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 // tag::entity-class[]
-import { ValueEntity, replies } from "@kalix-io/kalix-javascript-sdk";
+import { ValueEntity, Reply } from "@kalix-io/kalix-javascript-sdk";
 import * as proto from "../lib/generated/proto";
 
 /**
@@ -53,6 +53,9 @@ type DecreaseValue = proto.com.example.DecreaseValue;
 type ResetValue = proto.com.example.ResetValue;
 type GetCounter = proto.com.example.GetCounter;
 
+type Empty = proto.google.protobuf.IEmpty;
+type CurrentCounter = proto.com.example.ICurrentCounter;
+
 // tag::lookup-type[]
 const CounterState = entity.lookupType("com.example.domain.CounterState");
 // end::lookup-type[]
@@ -73,15 +76,15 @@ function increase(
   command: IncreaseValue,
   counter: State,
   ctx: Context
-): replies.Reply {
+): Reply<Empty> {
   if (command.value < 0) {
-    return replies.failure(
+    return Reply.failure(
       `Increase requires a positive value. It was [${command.value}].`
     );
   }
   counter.value += command.value;
   ctx.updateState(counter);
-  return replies.message({});
+  return Reply.message({});
 }
 // end::increase[]
 
@@ -89,30 +92,33 @@ function decrease(
   command: DecreaseValue,
   counter: State,
   ctx: Context
-): replies.Reply {
+): Reply<Empty> {
   if (command.value < 0) {
-    return replies.failure(
+    return Reply.failure(
       `Decrease requires a positive value. It was [${command.value}].`
     );
   }
   counter.value -= command.value;
   ctx.updateState(counter);
-  return replies.message({});
+  return Reply.message({});
 }
 
 function reset(
   command: ResetValue,
   counter: State,
   ctx: Context
-): replies.Reply {
+): Reply<Empty> {
   counter.value = 0;
   ctx.updateState(counter);
-  return replies.message({});
+  return Reply.message({});
 }
 
 // tag::get-current[]
-function getCurrentCounter(command: GetCounter, counter: State): replies.Reply {
-  return replies.message({ value: counter.value });
+function getCurrentCounter(
+  command: GetCounter,
+  counter: State
+): Reply<CurrentCounter> {
+  return Reply.message({ value: counter.value });
 }
 // end::get-current[]
 

--- a/samples/ts/ts-valueentity-counter/test/testkit.ts
+++ b/samples/ts/ts-valueentity-counter/test/testkit.ts
@@ -14,10 +14,7 @@
  * limitations under the License.
  */
 
-import {
-  Metadata,
-  ValueEntity
-} from "@kalix-io/kalix-javascript-sdk";
+import { Metadata, ValueEntity } from "@kalix-io/kalix-javascript-sdk";
 import { Message } from "protobufjs";
 
 /**

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -60,6 +60,7 @@ export { Serializable, TypedJson } from './src/serializable';
 
 import * as replies from './src/reply';
 export { replies };
+export { Reply } from './src/reply';
 
 export { GrpcStatus } from './src/grpc-status';
 export {

--- a/sdk/src/reply.ts
+++ b/sdk/src/reply.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Method } from 'protobufjs';
+import { EffectMethod } from './effect';
 import { Metadata } from './metadata';
 import { GrpcStatus } from './grpc-status';
 
@@ -31,7 +31,7 @@ export class Effect {
    * @param metadata - metadata to send with the effect
    */
   constructor(
-    readonly method: Method,
+    readonly method: EffectMethod,
     readonly message: any,
     readonly synchronous: boolean = false,
     readonly metadata?: Metadata,
@@ -41,12 +41,14 @@ export class Effect {
 /**
  * A return type to allow returning forwards or failures, and attaching effects to messages.
  *
+ * @typeParam Message - the type of the reply message
+ *
  * @public
  */
-export class Reply {
+export class Reply<Message = any> {
   constructor(
-    private method?: Method,
-    private message?: any,
+    private method?: EffectMethod,
+    private message?: Message,
     private metadata?: Metadata,
     private forward?: Reply,
     private failure?: Failure,
@@ -54,19 +56,87 @@ export class Reply {
   ) {}
 
   /**
+   * Create a message reply.
+   *
+   * @typeParam Message - the type of the reply message
+   * @param message - the message to reply with
+   * @param metadata - optional metadata to pass with the reply
+   * @returns a message reply
+   */
+  static message<Message>(
+    message: Message,
+    metadata?: Metadata,
+  ): Reply<Message> {
+    const reply = new Reply<Message>()
+      .setMessage(message)
+      .setMetadata(metadata);
+    return reply;
+  }
+
+  /**
+   * Create a forward reply.
+   *
+   * @typeParam Message - the type of the reply message
+   * @param method - the service call representing the forward
+   * @param message - the message to forward
+   * @param metadata -  optional metadata to pass with the forwarded message
+   * @returns a forward reply
+   */
+  static forward<Message>(
+    method: EffectMethod,
+    message: any,
+    metadata?: Metadata,
+  ): Reply<Message> {
+    const forward = new Reply()
+      .setMethod(method)
+      .setMessage(message)
+      .setMetadata(metadata);
+    const reply = new Reply<Message>().setForward(forward);
+    return reply;
+  }
+
+  /**
+   * Create a failure reply.
+   *
+   * @typeParam Message - the type of the reply message
+   * @param description - description of the failure
+   * @param status - the GRPC status, defaults to Unknown
+   * @returns a failure reply
+   */
+  static failure<Message>(
+    description: string,
+    status?: GrpcStatus,
+  ): Reply<Message> {
+    const reply = new Reply<Message>().setFailure(description, status);
+    return reply;
+  }
+
+  /**
+   * Create a reply that contains neither a message nor a forward nor a failure.
+   *
+   * This may be useful for emitting effects while sending an empty message.
+   *
+   * @typeParam Message - the type of the reply message
+   * @returns an empty reply
+   */
+  static empty<Message>(): Reply<Message> {
+    return new Reply<Message>();
+  }
+
+  /**
    * @returns the protobuf method for a forwarding reply
    */
-  getMethod(): Method | undefined {
+  getMethod(): EffectMethod | undefined {
     return this.method;
   }
 
   /**
-   * Set the protobuf method for a forwarding reply.
+   * Set the protobuf service method for a forwarding reply.
    *
-   * @param method - the protobuf method
+   * @param method - the protobuf service method
    * @returns the updated reply
    */
-  setMethod(method: Method): Reply {
+  setMethod(method: EffectMethod): Reply<Message> {
     this.method = method;
     return this;
   }
@@ -74,7 +144,7 @@ export class Reply {
   /**
    * @returns the reply message
    */
-  getMessage(): any {
+  getMessage(): Message | undefined {
     return this.message;
   }
 
@@ -83,7 +153,7 @@ export class Reply {
    * @param message - the reply message
    * @returns the updated reply
    */
-  setMessage(message: any): Reply {
+  setMessage(message: Message): Reply<Message> {
     this.message = message;
     return this;
   }
@@ -101,7 +171,7 @@ export class Reply {
    * @param metadata - metadata to send with the reply
    * @returns the updated reply
    */
-  setMetadata(metadata?: Metadata): Reply {
+  setMetadata(metadata?: Metadata): Reply<Message> {
     this.metadata = metadata;
     return this;
   }
@@ -119,7 +189,7 @@ export class Reply {
    * @param forward - the forward reply
    * @returns the updated reply
    */
-  setForward(forward: Reply): Reply {
+  setForward(forward: Reply): Reply<Message> {
     this.forward = forward;
     return this;
   }
@@ -138,7 +208,7 @@ export class Reply {
    * @param status - the status code to fail with, defaults to Unknown.
    * @returns the updated reply
    */
-  setFailure(description: string, status?: GrpcStatus): Reply {
+  setFailure(description: string, status?: GrpcStatus): Reply<Message> {
     this.failure = new Failure(description, status);
     return this;
   }
@@ -160,11 +230,11 @@ export class Reply {
    * @returns this reply after adding the effect
    */
   addEffect(
-    method: Method,
+    method: EffectMethod,
     message: any,
     synchronous: boolean = false,
     metadata: Metadata | undefined = undefined,
-  ): Reply {
+  ): Reply<Message> {
     this.addEffects([new Effect(method, message, synchronous, metadata)]);
     return this;
   }
@@ -175,7 +245,7 @@ export class Reply {
    * @param effects - service calls to execute as side effects
    * @returns this reply after adding the effects
    */
-  addEffects(effects: Effect[]): Reply {
+  addEffects(effects: Effect[]): Reply<Message> {
     if (this.effects) this.effects.push(...effects);
     else this.effects = effects;
     return this;
@@ -194,56 +264,60 @@ export class Reply {
 /**
  * Create a message reply.
  *
+ * @typeParam Message - the type of the reply message
  * @param message - the message to reply with
  * @param metadata - optional metadata to pass with the reply
  * @returns a message reply
  *
+ * @see also provided by {@link Reply.message}
+ *
  * @public
  */
-export function message(
-  message: any,
-  metadata: Metadata | undefined = undefined,
-): Reply {
-  const reply = new Reply().setMessage(message).setMetadata(metadata);
-  return reply;
+export function message<Message>(
+  message: Message,
+  metadata?: Metadata,
+): Reply<Message> {
+  return Reply.message(message, metadata);
 }
 
 /**
  * Create a forward reply.
  *
+ * @typeParam Message - the type of the reply message
  * @param method - the service call representing the forward
  * @param message - the message to forward
  * @param metadata -  optional metadata to pass with the forwarded message
  * @returns a forward reply
  *
+ * @see also provided by {@link Reply.forward}
+ *
  * @public
  */
-export function forward(
-  method: protobuf.Method,
+export function forward<Message>(
+  method: EffectMethod,
   message: any,
-  metadata: Metadata | undefined = undefined,
-): Reply {
-  const forward = new Reply()
-    .setMethod(method)
-    .setMessage(message)
-    .setMetadata(metadata);
-
-  const reply = new Reply().setForward(forward);
-  return reply;
+  metadata?: Metadata,
+): Reply<Message> {
+  return Reply.forward<Message>(method, message, metadata);
 }
 
 /**
  * Create a failure reply.
  *
+ * @typeParam Message - the type of the reply message
  * @param description - description of the failure
  * @param status - the GRPC status, defaults to Unknown
  * @returns a failure reply
  *
+ * @see also provided by {@link Reply.failure}
+ *
  * @public
  */
-export function failure(description: string, status?: GrpcStatus): Reply {
-  const reply = new Reply().setFailure(description, status);
-  return reply;
+export function failure<Message>(
+  description: string,
+  status?: GrpcStatus,
+): Reply<Message> {
+  return Reply.failure<Message>(description, status);
 }
 
 /**
@@ -251,12 +325,15 @@ export function failure(description: string, status?: GrpcStatus): Reply {
  *
  * This may be useful for emitting effects while sending an empty message.
  *
+ * @typeParam Message - the type of the reply message
  * @returns an empty reply
+ *
+ * @see also provided by {@link Reply.empty}
  *
  * @public
  */
-export function emptyReply(): Reply {
-  return new Reply();
+export function emptyReply<Message>(): Reply<Message> {
+  return Reply.empty<Message>();
 }
 
 /** @public */

--- a/sdk/test/reply.test.ts
+++ b/sdk/test/reply.test.ts
@@ -64,24 +64,23 @@ describe('Replies', () => {
   });
 
   it('should create a forward Reply', () => {
-    // Arrange
-    const reply = replies.forward(
-      new protobuf.Method('my-method', 'rpc', 'my-request', 'my-response'),
-      'my-msg',
-      new Metadata(),
+    const method = new protobuf.Method(
+      'my-method',
+      'rpc',
+      'my-request',
+      'my-response',
     );
+    const reply = replies.forward(method, 'my-msg', new Metadata());
 
-    // Act
     const forward = reply.getForward();
 
-    // Assert
     expect(reply.isEmpty()).to.be.false;
     expect(reply.getMethod()).to.be.undefined;
     expect(reply.getMessage()).to.be.undefined;
     expect(reply.getMetadata()).to.be.undefined;
     expect(reply.getFailure()).to.be.undefined;
     expect(reply.getEffects()).to.be.empty;
-    expect(forward?.getMethod()?.name).to.be.eq('my-method');
+    expect(forward?.getMethod()).to.be.eq(method);
     expect(forward?.getMessage()).to.be.eq('my-msg');
   });
 
@@ -98,39 +97,35 @@ describe('Replies', () => {
   });
 
   it('should add synchronous effects to a message', () => {
-    // Arrange
     const reply = replies.message('my-msg', new Metadata());
 
-    // Act
-    reply.addEffect(
-      new protobuf.Method('my-method', 'rpc', 'my-request', 'my-response'),
-      'my-msg',
-      true,
-      new Metadata(),
+    const method = new protobuf.Method(
+      'my-method',
+      'rpc',
+      'my-request',
+      'my-response',
     );
+    reply.addEffect(method, 'my-msg', true, new Metadata());
     const effect = reply.getEffects()[0];
 
-    // Assert
-    expect(effect.method.name).to.be.eq('my-method');
+    expect(effect.method).to.be.eq(method);
     expect(effect.message).to.be.eq('my-msg');
     expect(effect.synchronous).to.be.true;
   });
 
   it('should add not synchronous effects to a message', () => {
-    // Arrange
     const reply = replies.message('my-msg', new Metadata());
 
-    // Act
-    reply.addEffect(
-      new protobuf.Method('my-method', 'rpc', 'my-request', 'my-response'),
-      'my-msg',
-      false,
-      new Metadata(),
+    const method = new protobuf.Method(
+      'my-method',
+      'rpc',
+      'my-request',
+      'my-response',
     );
+    reply.addEffect(method, 'my-msg', false, new Metadata());
     const effect = reply.getEffects()[0];
 
-    // Assert
-    expect(effect.method.name).to.be.eq('my-method');
+    expect(effect.method).to.be.eq(method);
     expect(effect.message).to.be.eq('my-msg');
     expect(effect.synchronous).to.be.false;
   });

--- a/tck/src/action.ts
+++ b/tck/src/action.ts
@@ -19,6 +19,7 @@ import { replies } from '@kalix-io/kalix-javascript-sdk';
 import protocol from '../generated/tck';
 
 type Request = protocol.kalix.tck.model.action.Request;
+type Response = protocol.kalix.tck.model.action.Response;
 type IProcessGroup = protocol.kalix.tck.model.action.IProcessGroup;
 
 const { Request, Response } = protocol.kalix.tck.model.action;
@@ -33,7 +34,7 @@ export const tckModel = new Action(
   ProcessStreamed: processStreamed,
 });
 
-function processUnary(request: Request) {
+function processUnary(request: Request): replies.Reply<Response> {
   return createReplyForGroup(request.groups[0]);
 }
 
@@ -76,12 +77,12 @@ function processStreamed(context: Action.StreamedCommandContext) {
   context.on('end', () => context.end());
 }
 
-function createReplies(request: Request): replies.Reply[] {
+function createReplies(request: Request): replies.Reply<Response>[] {
   return request.groups.map(createReplyForGroup);
 }
 
-function createReplyForGroup(group: IProcessGroup): replies.Reply {
-  let reply = replies.emptyReply();
+function createReplyForGroup(group: IProcessGroup): replies.Reply<Response> {
+  let reply = replies.emptyReply<Response>();
   group.steps?.forEach((step) => {
     if (step.reply) {
       reply = replies.message(Response.create({ message: step.reply.message }));

--- a/tck/src/value-entity.ts
+++ b/tck/src/value-entity.ts
@@ -15,10 +15,11 @@
  */
 
 import { ValueEntity } from '@kalix-io/kalix-javascript-sdk';
-import { replies } from '@kalix-io/kalix-javascript-sdk';
+import { Reply, replies } from '@kalix-io/kalix-javascript-sdk';
 import protocol from '../generated/tck';
 
 type Request = protocol.kalix.tck.model.valueentity.Request;
+type Response = protocol.kalix.tck.model.valueentity.Response;
 
 const { Request, Response } = protocol.kalix.tck.model.valueentity;
 
@@ -43,8 +44,8 @@ function process(
   request: Request,
   state: Persisted,
   context: ValueEntity.ValueEntityCommandContext,
-): replies.Reply {
-  let reply: replies.Reply | undefined,
+): Reply<Response> {
+  let reply: Reply<Response> | undefined,
     effects: replies.Effect[] = [];
   request.actions.forEach((action) => {
     if (action.update) {
@@ -54,7 +55,7 @@ function process(
       state.value = undefined;
       context.deleteState();
     } else if (action.forward) {
-      reply = replies.forward(two.service.methods.Call, {
+      reply = Reply.forward(two.service.methods.Call, {
         id: action.forward.id,
       });
     } else if (action.effect) {
@@ -66,11 +67,11 @@ function process(
         ),
       );
     } else if (action.fail) {
-      reply = replies.failure(action.fail.message || '');
+      reply = Reply.failure(action.fail.message || '');
     }
   });
   if (!reply)
-    reply = replies.message(
+    reply = Reply.message(
       Response.create(state.value ? { message: state.value } : {}),
     );
   reply.addEffects(effects);


### PR DESCRIPTION
Refs #320 (and rather than do all type improvements in one go, breaking it up into different areas).

Make `Reply` generic over its message type, to be able to type the responses for handlers. Type parameter defaults to `any` so that untyped is still supported.

Also re-export `Reply` from top-level and add the reply factory functions as static methods to `Reply` — which I think feels more natural for factory methods. And simplifies it slightly compared with prefixing with the `replies` namespace. Old approach still supported as well.

Some samples and tests are updated to use the generic Reply and methods, others left as is for old approach.

We could also create the same API as for Java/Scala SDKs, but that would either be a breaking a change, or probably odd to have both `Reply.message` and `Effect.reply` and `context.emit` and `Effect.emit` and so on.
