### PR TITLE
feat: make replicated data types generic

### DIFF
--- a/samples/ts/ts-replicated-entity-shopping-cart/src/shoppingcart.ts
+++ b/samples/ts/ts-replicated-entity-shopping-cart/src/shoppingcart.ts
@@ -32,6 +32,8 @@ type RemoveShoppingCart = proto.com.example.shoppingcart.RemoveShoppingCart;
 
 type Context = replicatedentity.ReplicatedEntityCommandContext;
 
+type Product = proto.com.example.shoppingcart.domain.IProduct & protobuf.Message;
+
 // end::types[]
 // tag::class[]
 const entity = new replicatedentity.ReplicatedEntity( // <1>
@@ -45,7 +47,7 @@ const entity = new replicatedentity.ReplicatedEntity( // <1>
 // end::class[]
 
 // tag::defaultValue[]
-entity.defaultValue = () => new replicatedentity.ReplicatedCounterMap(); // <1>
+entity.defaultValue = () => new replicatedentity.ReplicatedCounterMap<Product>(); // <1>
 // end::defaultValue[]
 
 // tag::types[]
@@ -69,7 +71,7 @@ function addItem(addLineItem: AddLineItem, context: Context) {
     return replies.failure(`Quantity for item ${addLineItem.productId} must be greater than zero`); // <1>
   }
 
-  const cart = context.state as replicatedentity.ReplicatedCounterMap; // <2>
+  const cart = context.state as replicatedentity.ReplicatedCounterMap<Product>; // <2>
 
   const product = Product.create({
     id: addLineItem.productId, // <3>
@@ -83,7 +85,7 @@ function addItem(addLineItem: AddLineItem, context: Context) {
 // end::addItem[]
 
 function removeItem(removeLineItem: RemoveLineItem, context: Context) {
-  const cart = context.state as replicatedentity.ReplicatedCounterMap;
+  const cart = context.state as replicatedentity.ReplicatedCounterMap<Product>;
 
   const product = Product.create({
     id: removeLineItem.productId,
@@ -101,7 +103,7 @@ function removeItem(removeLineItem: RemoveLineItem, context: Context) {
 
 // tag::getCart[]
 function getCart(getShoppingCart: GetShoppingCart, context: Context) {
-  const cart = context.state as replicatedentity.ReplicatedCounterMap; // <1>
+  const cart = context.state as replicatedentity.ReplicatedCounterMap<Product>; // <1>
 
   const items = Array.from(cart.keys()) // <2>
     .map(product => ({

--- a/sdk/bin/compile-protobuf.sh
+++ b/sdk/bin/compile-protobuf.sh
@@ -37,6 +37,24 @@ $PROTOC \
 rm -rf test/proto
 cp -r proto test/
 
+pbjs -t static-module -w commonjs \
+  -o ./test/proto/test-protobuf-bundle.js \
+  -p ./proto -p ./protoc/include \
+  ./proto/kalix/*.proto \
+  ./proto/kalix/protocol/*.proto \
+  ./proto/kalix/component/*.proto \
+  ./proto/kalix/component/*/*.proto \
+  ./test/*.proto
+
+pbjs -t static-module \
+  -p ./proto -p ./protoc/include \
+  ./proto/kalix/*.proto \
+  ./proto/kalix/protocol/*.proto \
+  ./proto/kalix/component/*.proto \
+  ./proto/kalix/component/*/*.proto \
+  ./test/*.proto \
+  | pbts -o ./test/proto/test-protobuf-bundle.d.ts -
+
 OUT_DIR="${PWD}/test/proto"
 TS_OUT_DIR="${PWD}/test/proto"
 

--- a/sdk/src/event-sourced-entity.ts
+++ b/sdk/src/event-sourced-entity.ts
@@ -99,7 +99,7 @@ export namespace EventSourcedEntity {
    * @param state - The entity state
    * @returns The new entity state
    */
-  export type BehaviorCallback = (state: Serializable) => Behavior;
+  export type BehaviorCallback = (state: any) => Behavior;
 
   /**
    * Initial state callback.

--- a/sdk/src/replicated-data/counter-map.ts
+++ b/sdk/src/replicated-data/counter-map.ts
@@ -34,19 +34,23 @@ namespace protocol {
     proto.kalix.component.replicatedentity.IReplicatedCounterMapEntryDelta;
 }
 
-interface Entry {
-  key: Serializable;
+interface Entry<Key extends Serializable> {
+  key: Key;
   counter: ReplicatedCounter;
 }
 
 /**
  * A replicated map of counters.
  *
+ * @typeParam Key - Type of keys for the Replicated Counter Map
+ *
  * @public
  */
-export class ReplicatedCounterMap implements ReplicatedData {
-  private counters = new Map<Comparable, Entry>();
-  private removed = new Map<Comparable, Serializable>();
+export class ReplicatedCounterMap<Key extends Serializable = Serializable>
+  implements ReplicatedData
+{
+  private counters = new Map<Comparable, Entry<Key>>();
+  private removed = new Map<Comparable, Key>();
   private cleared = false;
 
   /**
@@ -55,7 +59,7 @@ export class ReplicatedCounterMap implements ReplicatedData {
    * @param key - The key to get
    * @returns The counter value, or undefined if no value is defined at that key
    */
-  get = (key: Serializable): number | undefined => {
+  get = (key: Key): number | undefined => {
     const entry = this.counters.get(AnySupport.toComparable(key));
     return entry !== undefined ? entry.counter.value : undefined;
   };
@@ -66,7 +70,7 @@ export class ReplicatedCounterMap implements ReplicatedData {
    * @param key - The key to get
    * @returns The counter value as a long, or undefined if no value is defined at that key
    */
-  getLong = (key: Serializable): Long.Long | undefined => {
+  getLong = (key: Key): Long.Long | undefined => {
     const entry = this.counters.get(AnySupport.toComparable(key));
     return entry !== undefined ? entry.counter.longValue : undefined;
   };
@@ -79,9 +83,9 @@ export class ReplicatedCounterMap implements ReplicatedData {
    * @returns This counter map
    */
   increment = (
-    key: Serializable,
+    key: Key,
     increment: Long.Long | number,
-  ): ReplicatedCounterMap => {
+  ): ReplicatedCounterMap<Key> => {
     this.getOrCreateCounter(key).increment(increment);
     return this;
   };
@@ -94,9 +98,9 @@ export class ReplicatedCounterMap implements ReplicatedData {
    * @returns This counter map
    */
   decrement = (
-    key: Serializable,
+    key: Key,
     decrement: Long.Long | number,
-  ): ReplicatedCounterMap => {
+  ): ReplicatedCounterMap<Key> => {
     this.getOrCreateCounter(key).decrement(decrement);
     return this;
   };
@@ -107,7 +111,7 @@ export class ReplicatedCounterMap implements ReplicatedData {
    * @param key - The key to check
    * @returns True if this counter map contains a value for the given key
    */
-  has = (key: Serializable): boolean => {
+  has = (key: Key): boolean => {
     return this.counters.has(AnySupport.toComparable(key));
   };
 
@@ -121,7 +125,7 @@ export class ReplicatedCounterMap implements ReplicatedData {
   /**
    * Return an (iterable) iterator of the keys of this counter map.
    */
-  keys = (): IterableIterator<Serializable> => {
+  keys = (): IterableIterator<Key> => {
     return iterators.map(this.counters.values(), (entry) => entry.key);
   };
 
@@ -132,7 +136,7 @@ export class ReplicatedCounterMap implements ReplicatedData {
    * @returns This counter map
    */
 
-  delete = (key: Serializable): ReplicatedCounterMap => {
+  delete = (key: Key): ReplicatedCounterMap<Key> => {
     const comparableKey = AnySupport.toComparable(key);
     if (this.counters.has(comparableKey)) {
       this.counters.delete(comparableKey);
@@ -146,7 +150,7 @@ export class ReplicatedCounterMap implements ReplicatedData {
    *
    * @returns This counter map
    */
-  clear = (): ReplicatedCounterMap => {
+  clear = (): ReplicatedCounterMap<Key> => {
     if (this.counters.size > 0) {
       this.cleared = true;
       this.counters.clear();
@@ -155,7 +159,7 @@ export class ReplicatedCounterMap implements ReplicatedData {
     return this;
   };
 
-  private getOrCreateCounter(key: Serializable): ReplicatedCounter {
+  private getOrCreateCounter(key: Key): ReplicatedCounter {
     const comparableKey = AnySupport.toComparable(key);
     const entry = this.counters.get(comparableKey);
     if (entry) {

--- a/sdk/src/replicated-data/register.ts
+++ b/sdk/src/replicated-data/register.ts
@@ -41,10 +41,14 @@ namespace protocol {
  * time, custom clocks can supply a custom number to be used. If two clock values are equal, the
  * write from the node with the lowest address wins.
  *
+ * @typeParam Value - Type of value stored by the register
+ *
  * @public
  */
-export class ReplicatedRegister implements ReplicatedData {
-  private currentValue: Serializable;
+export class ReplicatedRegister<Value extends Serializable = Serializable>
+  implements ReplicatedData
+{
+  private currentValue: Value;
   private delta: protocol.RegisterDelta;
 
   /**
@@ -55,7 +59,7 @@ export class ReplicatedRegister implements ReplicatedData {
    * @param customClockValue - The custom clock value, if using a custom clock
    */
   constructor(
-    value: Serializable,
+    value: Value,
     clock: Clock = Clocks.DEFAULT,
     customClockValue: number | Long = 0,
   ) {
@@ -80,11 +84,11 @@ export class ReplicatedRegister implements ReplicatedData {
    *
    * @remarks Sets with the default clock.
    */
-  get value(): Serializable {
+  get value(): Value {
     return this.currentValue;
   }
 
-  set value(value: Serializable) {
+  set value(value: Value) {
     this.setWithClock(value);
   }
 
@@ -96,10 +100,10 @@ export class ReplicatedRegister implements ReplicatedData {
    * @param customClockValue - Custom clock value, or ignored if a custom clock isn't specified
    */
   setWithClock = (
-    value: Serializable,
+    value: Value,
     clock: Clock = Clocks.DEFAULT,
     customClockValue: number | Long = 0,
-  ): ReplicatedRegister => {
+  ): ReplicatedRegister<Value> => {
     this.delta = {
       value: AnySupport.serialize(value, true, true),
       clock: clock,

--- a/sdk/src/serializable.ts
+++ b/sdk/src/serializable.ts
@@ -35,7 +35,7 @@ export interface TypedJson {
 export type Serializable =
   | protobuf.Message
   | TypedJson
-  | any
+  | object
   | string
   | number
   | boolean

--- a/sdk/test/replicated-data/map-test.ts
+++ b/sdk/test/replicated-data/map-test.ts
@@ -36,8 +36,10 @@ namespace protocol {
 const root = new protobuf.Root();
 root.loadSync(path.join(__dirname, '..', 'example.proto'));
 root.resolveAll();
-const Example = root.lookupType('com.example.Example');
 const anySupport = new AnySupport(root);
+
+// serialized state needs to be reflective type
+const Example = root.lookupType('com.example.Example');
 
 function roundTripDelta(delta: protocol.Delta | null): protocol.Delta {
   return delta
@@ -85,7 +87,7 @@ describe('ReplicatedMap', () => {
   });
 
   it('should reflect an initial delta', () => {
-    const map = new ReplicatedMap();
+    const map = new ReplicatedMap<string, replicatedData.ReplicatedCounter>();
     map.applyDelta(
       roundTripDelta({
         replicatedMap: {
@@ -107,10 +109,10 @@ describe('ReplicatedMap', () => {
   });
 
   it('should generate an add delta', () => {
-    const map = new ReplicatedMap().set(
-      'one',
-      new replicatedData.ReplicatedCounter(),
-    );
+    const map = new ReplicatedMap<
+      string,
+      replicatedData.ReplicatedCounter
+    >().set('one', new replicatedData.ReplicatedCounter());
     map.has('one').should.be.true;
     map.size.should.equal(1);
     const delta1 = roundTripDelta(map.getAndResetDelta());

--- a/sdk/test/replicated-data/multi-map-test.ts
+++ b/sdk/test/replicated-data/multi-map-test.ts
@@ -19,7 +19,7 @@ import { ReplicatedMultiMap } from '../../src/replicated-data/multi-map';
 import * as path from 'path';
 import * as protobuf from 'protobufjs';
 import AnySupport from '../../src/protobuf-any';
-import * as proto from '../proto/protobuf-bundle';
+import * as proto from '../proto/test-protobuf-bundle';
 
 namespace protocol {
   export type Any = proto.google.protobuf.IAny;
@@ -34,8 +34,10 @@ namespace protocol {
 const root = new protobuf.Root();
 root.loadSync(path.join(__dirname, '..', 'example.proto'));
 root.resolveAll();
-const Example = root.lookupType('com.example.Example');
 const anySupport = new AnySupport(root);
+
+// serialized state needs to be reflective type
+const Example = root.lookupType('com.example.Example');
 
 function roundTripDelta(delta: protocol.Delta | null): protocol.Delta {
   return delta
@@ -110,7 +112,7 @@ describe('ReplicatedMultiMap', () => {
   });
 
   it('should generate a delta with added entries', () => {
-    const multiMap = new ReplicatedMultiMap();
+    const multiMap = new ReplicatedMultiMap<string, string>();
     multiMap.put('key1', 'value1');
     multiMap.putAll('key2', ['value2', 'value3']);
 
@@ -159,7 +161,7 @@ describe('ReplicatedMultiMap', () => {
   });
 
   it('should generate a delta with updated entries', () => {
-    const multiMap = new ReplicatedMultiMap();
+    const multiMap = new ReplicatedMultiMap<string, string>();
     multiMap.put('key1', 'value1');
     multiMap.putAll('key2', ['value2', 'value3']);
     multiMap.keysSize.should.equal(2);
@@ -213,7 +215,7 @@ describe('ReplicatedMultiMap', () => {
   });
 
   it('should reflect a delta with added entries', () => {
-    const multiMap = new ReplicatedMultiMap();
+    const multiMap = new ReplicatedMultiMap<string, string>();
     multiMap.put('key1', 'value1');
     multiMap.getAndResetDelta();
 
@@ -343,7 +345,7 @@ describe('ReplicatedMultiMap', () => {
   });
 
   it('should support json objects for keys and values', () => {
-    const multiMap = new ReplicatedMultiMap();
+    const multiMap = new ReplicatedMultiMap<{ foo: string }, { foo: string }>();
     multiMap.put({ foo: 'key1' }, { foo: 'value1' });
     multiMap.put({ foo: 'key2' }, { foo: 'value2' });
     multiMap.putAll({ foo: 'key3' }, [{ foo: 'value3' }, { foo: 'value4' }]);


### PR DESCRIPTION
Refs #320.

Make replicated data types generic. Replicated entity state is not yet generic, so this is just the underlying step towards that. Entities may need a bit of reworking to have this ripple through the contexts in particular.

The typing for serialized state is still awkward in TypeScript, with it requiring the reflective Message type, but should be able to improve on this and use the generated protobuf directly (see #326).

The type parameters will default to `Serializable` to have the same behaviour as before. Some tests are updated, others left as is.

Note that this used single letter type parameters at first (`T`, `E`, `K`, `V` and so on), but the latest TypeScript docs are now using full names, so I've followed the full name convention here as well.