### PR TITLE
fix: set component settings for actions

### DIFF
--- a/sdk/src/kalix.ts
+++ b/sdk/src/kalix.ts
@@ -694,6 +694,7 @@ export class Kalix {
               componentOptions.forwardHeaders,
             );
           }
+          res.setComponent(componentSettings);
         }
 
         return res;


### PR DESCRIPTION
Forward headers for actions was broken. Looks like this line was inadvertently removed in #269 with the renaming.

Must be missing tests for this. As it's part of the SDK protocol, probably useful to have it in the TCK.