### PR TITLE
chore: tweak typedoc settings

### DIFF
--- a/sdk/src/event-sourced-entity.ts
+++ b/sdk/src/event-sourced-entity.ts
@@ -131,8 +131,8 @@ export namespace EventSourcedEntity {
    *
    * @typeParam State - the type of {@link Serializable} state
    * @typeParam Events - the type of all {@link Serializable} events
-   * @typeParam CommandHandlers - optional type of {@link EventSourcedEntity.CommandHandlers}
-   * @typeParam EventHandlers - optional type of {@link EventSourcedEntity.EventHandlers}
+   * @typeParam CommandHandlers - optional type of {@link CommandHandlers}
+   * @typeParam EventHandlers - optional type of {@link EventHandlers}
    */
   export type Behavior<
     State extends Serializable = any,
@@ -170,8 +170,8 @@ export namespace EventSourcedEntity {
    *
    * @typeParam State - the type of {@link Serializable} state
    * @typeParam Events - the type of all {@link Serializable} events
-   * @typeParam CommandHandlers - optional type of {@link EventSourcedEntity.CommandHandlers}
-   * @typeParam EventHandlers - optional type of {@link EventSourcedEntity.EventHandlers}
+   * @typeParam CommandHandlers - optional type of {@link CommandHandlers}
+   * @typeParam EventHandlers - optional type of {@link EventHandlers}
    * @param state - The entity state
    * @returns The new entity state
    */
@@ -251,8 +251,8 @@ const defaultOptions = {
  *
  * @typeParam State - the type of {@link Serializable} state
  * @typeParam Events - the type of all {@link Serializable} events
- * @typeParam CommandHandlers - optional type of {@link EventSourcedEntity.CommandHandlers}
- * @typeParam EventHandlers - optional type of {@link EventSourcedEntity.EventHandlers}
+ * @typeParam CommandHandlers - optional type of CommandHandlers
+ * @typeParam EventHandlers - optional type of EventHandlers
  *
  * @public
  */

--- a/sdk/src/value-entity.ts
+++ b/sdk/src/value-entity.ts
@@ -137,7 +137,7 @@ const defaultOptions = {
  * Value Entity.
  *
  * @typeParam State - the type of {@link Serializable} state
- * @typeParam CommandHandlers - optional type of {@link ValueEntity.CommandHandlers}
+ * @typeParam CommandHandlers - optional type of CommandHandlers
  *
  * @public
  */

--- a/sdk/typedoc.json
+++ b/sdk/typedoc.json
@@ -1,9 +1,15 @@
 {
   "$schema": "https://typedoc.org/schema.json",
-  "entryPoints": [
-    "./index.ts"
-  ],
+  "entryPoints": ["./index.ts"],
   "excludeInternal": true,
   "excludePrivate": true,
+  "readme": "none",
+  "sort": ["source-order"],
+  "validation": {
+    "notExported": true,
+    "invalidLink": true,
+    "notDocumented": false
+  },
+  "treatWarningsAsErrors": true,
   "out": "apidocs"
 }


### PR DESCRIPTION
Tweak the typedoc settings a little.

Skip the readme page (which just links to the main docs anyway) and go straight to the index page.

Use source order sorting. This order is usually meaningful in each source file, so could be better to read in the API docs, rather than just alphabetical.

Warn on invalid links. A few links were actually invalid for typedoc (while valid for vscode).

Warnings to errors, to fail on missing exports or invalid links.