### PR TITLE
rename: fix 'SDK SDK' typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Kalix JavaScript SDK SDK
+# Kalix JavaScript SDK
 
 Source code for the [@kalix-io/kalix-javascript-sdk](https://www.npmjs.com/package/@kalix-io/kalix-javascript-sdk) package.
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,4 @@
-# Make Kalix JavaScript SDK SDK documentation
+# Make Kalix JavaScript SDK documentation
 
 module   := javascript
 upstream := lightbend/kalix-javascript-sdk

--- a/npm-js/create-kalix-entity/template/base/README.md
+++ b/npm-js/create-kalix-entity/template/base/README.md
@@ -21,7 +21,7 @@ To understand Kalix services, `protobuf` descriptors, and Entities, see the docu
 ## Developing
 
 This project has a bare-bones service ready for you to adapt and
-extend. To see the range of functionality available for you to use with the Kalix JavaScript SDK SDK, see the documentation [JavaScript section](https://docs.kalix.io/javascript/index.html). After you have modified any source files, build and the tools will preserve your changes as well as generate stubs for you to implement.
+extend. To see the range of functionality available for you to use with the Kalix JavaScript SDK, see the documentation [JavaScript section](https://docs.kalix.io/javascript/index.html). After you have modified any source files, build and the tools will preserve your changes as well as generate stubs for you to implement.
 
 ## Building
 

--- a/samples/js/js-replicated-entity-example/package.json
+++ b/samples/js/js-replicated-entity-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "js-replicated-entity-example",
   "version": "0.0.0",
-  "description": "Kalix JavaScript SDK SDK example for replicated entities",
+  "description": "Kalix JavaScript SDK example for replicated entities",
   "homepage": "https://github.com/lightbend/kalix-javascript-sdk",
   "bugs": {
     "url": "https://github.com/lightbend/kalix-javascript-sdk/issues"

--- a/samples/js/js-views-example/package.json
+++ b/samples/js/js-views-example/package.json
@@ -1,7 +1,7 @@
 {
   "name": "js-views-example",
   "version": "0.0.0",
-  "description": "Kalix JavaScript SDK SDK example that demonstrates views",
+  "description": "Kalix JavaScript SDK example that demonstrates views",
   "engineStrict": true,
   "engines": {
     "node": "~14"

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kalix-io/kalix-javascript-sdk",
   "version": "0.0.0",
-  "description": "Kalix JavaScript SDK SDK",
+  "description": "Kalix JavaScript SDK",
   "keywords": [
     "kalix",
     "serverless"


### PR DESCRIPTION
`SDK SDK` was introduced at some point in the renaming 