### PR TITLE
docs: update the testkit version in bundle downloads

### DIFF
--- a/docs/bin/bundle.sh
+++ b/docs/bin/bundle.sh
@@ -45,6 +45,9 @@ function _set_sdk_version {
   if [ -n "$("$json" -q -f "$dir/package.json" "devDependencies['@kalix-io/kalix-scripts']")" ] ; then
     "$json" -q -I -f "$dir/package.json" -e "this.devDependencies['@kalix-io/kalix-scripts'] = '$sdk_version'"
   fi
+  if [ -n "$("$json" -q -f "$dir/package.json" "devDependencies['@kalix-io/testkit']")" ] ; then
+    "$json" -q -I -f "$dir/package.json" -e "this.devDependencies['@kalix-io/testkit'] = '$sdk_version'"
+  fi
 }
 
 function _bundle {


### PR DESCRIPTION
Follow-up to #339. Make sure the testkit version is updated when creating bundles on release.