### PR TITLE
fix: support async command handlers in codegen and testkit

### DIFF
--- a/codegen/js-gen/src/main/scala/io/kalix/codegen/js/EntityServiceSourceGenerator.scala
+++ b/codegen/js-gen/src/main/scala/io/kalix/codegen/js/EntityServiceSourceGenerator.scala
@@ -219,8 +219,11 @@ object EntityServiceSourceGenerator {
               command.fqn.name <> colon <+> parens(nest(line <>
               "command" <> colon <+> apiClass(command.inputType) <> comma <> line <>
               "state" <> colon <+> "State" <> comma <> line <>
-              "ctx" <> colon <+> "CommandContext") <> line) <+> "=>" <+> "CommandReply" <> angles(
-                apiInterface(command.outputType)) <> semi
+              "ctx" <> colon <+> "CommandContext") <> line) <+> "=>" <+> ssep(
+                Seq(
+                  "CommandReply" <> angles(apiInterface(command.outputType)),
+                  "Promise" <> angles("CommandReply" <> angles(apiInterface(command.outputType)))),
+                " | ") <> semi
             },
             line)) <> line) <> semi) <> line) <> line <>
       line <>
@@ -286,12 +289,12 @@ object EntityServiceSourceGenerator {
           service.commands.map { command =>
             "describe" <> parens(dquotes(command.fqn.name) <> comma <+> arrowFn(
               List.empty,
-              "it" <> parens(dquotes("should...") <> comma <+> arrowFn(
+              "it" <> parens(dquotes("should...") <> comma <+> "async" <+> arrowFn(
                 List.empty,
                 "const entity" <+> equal <+> "new" <+> entityMockType <> parens(
                   entityName <> comma <+> "entityId") <> semi <> line <>
                 "// TODO: you may want to set fields in addition to the entity id" <> line <>
-                "// const result" <+> equal <+> "entity.handleCommand" <> parens(
+                "// const result" <+> equal <+> "await" <+> "entity.handleCommand" <> parens(
                   dquotes(command.fqn.name) <> comma <+> braces(" entityId ")) <> semi <> line <>
                 line <>
                 "// expect" <> parens("result") <> dot <> "to" <> dot <> "deep" <> dot <> "equal" <> parens(

--- a/codegen/js-gen/src/test/scala/io/kalix/codegen/js/EntityServiceSourceGeneratorSuite.scala
+++ b/codegen/js-gen/src/test/scala/io/kalix/codegen/js/EntityServiceSourceGeneratorSuite.scala
@@ -204,12 +204,12 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |      command: api.SetValue,
         |      state: State,
         |      ctx: CommandContext
-        |    ) => CommandReply<api.IEmpty>;
+        |    ) => CommandReply<api.IEmpty> | Promise<CommandReply<api.IEmpty>>;
         |    Get: (
         |      command: api.GetValue,
         |      state: State,
         |      ctx: CommandContext
-        |    ) => CommandReply<api.IMyState>;
+        |    ) => CommandReply<api.IMyState> | Promise<CommandReply<api.IMyState>>;
         |  };
         |}
         |
@@ -261,12 +261,12 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |      command: api.SetValue,
         |      state: State,
         |      ctx: CommandContext
-        |    ) => CommandReply<api.IEmpty>;
+        |    ) => CommandReply<api.IEmpty> | Promise<CommandReply<api.IEmpty>>;
         |    Get: (
         |      command: api.GetValue,
         |      state: State,
         |      ctx: CommandContext
-        |    ) => CommandReply<api.IMyState>;
+        |    ) => CommandReply<api.IMyState> | Promise<CommandReply<api.IMyState>>;
         |  };
         |}
         |
@@ -301,10 +301,10 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |  const entityId = "entityId";
         |  
         |  describe("Set", () => {
-        |    it("should...", () => {
+        |    it("should...", async () => {
         |      const entity = new MockEventSourcedEntity(myentity, entityId);
         |      // TODO: you may want to set fields in addition to the entity id
-        |      // const result = entity.handleCommand("Set", { entityId });
+        |      // const result = await entity.handleCommand("Set", { entityId });
         |      
         |      // expect(result).to.deep.equal({});
         |      // expect(entity.error).to.be.undefined;
@@ -314,10 +314,10 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |  });
         |  
         |  describe("Get", () => {
-        |    it("should...", () => {
+        |    it("should...", async () => {
         |      const entity = new MockEventSourcedEntity(myentity, entityId);
         |      // TODO: you may want to set fields in addition to the entity id
-        |      // const result = entity.handleCommand("Get", { entityId });
+        |      // const result = await entity.handleCommand("Get", { entityId });
         |      
         |      // expect(result).to.deep.equal({});
         |      // expect(entity.error).to.be.undefined;
@@ -352,10 +352,10 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |  const entityId = "entityId";
         |  
         |  describe("Set", () => {
-        |    it("should...", () => {
+        |    it("should...", async () => {
         |      const entity = new MockValueEntity(myvalueentity, entityId);
         |      // TODO: you may want to set fields in addition to the entity id
-        |      // const result = entity.handleCommand("Set", { entityId });
+        |      // const result = await entity.handleCommand("Set", { entityId });
         |      
         |      // expect(result).to.deep.equal({});
         |      // expect(entity.error).to.be.undefined;
@@ -364,10 +364,10 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |  });
         |  
         |  describe("Get", () => {
-        |    it("should...", () => {
+        |    it("should...", async () => {
         |      const entity = new MockValueEntity(myvalueentity, entityId);
         |      // TODO: you may want to set fields in addition to the entity id
-        |      // const result = entity.handleCommand("Get", { entityId });
+        |      // const result = await entity.handleCommand("Get", { entityId });
         |      
         |      // expect(result).to.deep.equal({});
         |      // expect(entity.error).to.be.undefined;

--- a/samples/js/js-eventsourced-shopping-cart/test/shoppingcart.test.js
+++ b/samples/js/js-eventsourced-shopping-cart/test/shoppingcart.test.js
@@ -28,13 +28,13 @@ describe("ShoppingCartService", () => {
   const entityId = "entityId";
 
   describe("AddItem", () => {
-    it("should respond to addItem commands", () => {
+    it("should respond to addItem commands", async () => {
       const entity = new MockEventSourcedEntity(shoppingcart, entityId);
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", {cartId: "cart1", productId: "a", name: "Apple", quantity: 1});
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", {cartId: "cart1", productId: "b", name: "Banana", quantity: 2});
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", {cartId: "cart1", productId: "c", name: "Cantaloupe", quantity: 3});
 
       expect(entity.error).to.be.undefined;
@@ -56,12 +56,12 @@ describe("ShoppingCartService", () => {
   });
 
   describe("RemoveItem", () => {
-    it("should remove items from a cart", () => {
+    it("should remove items from a cart", async () => {
       const entity = new MockEventSourcedEntity(shoppingcart, entityId);
 
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", {cartId: "cart1", productId: "a", name: "Apple", quantity: 1});
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", {cartId: "cart1", productId: "b", name: "Banana", quantity: 2});
 
       expect(entity.error).to.be.undefined;
@@ -78,7 +78,7 @@ describe("ShoppingCartService", () => {
           ItemAdded.create({item: {productId: 'b', name: 'Banana', quantity: 2}}),
         ]);
 
-      entity.handleCommand(
+      await entity.handleCommand(
         "RemoveItem", {cartId: "cart1", productId: "a"});
       expect(entity.error).to.be.undefined;
       expect(entity.state.items)
@@ -97,9 +97,9 @@ describe("ShoppingCartService", () => {
   });
 
   describe("GetCart", () => {
-    it("should default to an empty cart", () => {
+    it("should default to an empty cart", async () => {
       const entity = new MockEventSourcedEntity(shoppingcart, entityId);
-      const result = entity.handleCommand("GetCart", {entityId});
+      const result = await entity.handleCommand("GetCart", {entityId});
       expect(result).to.deep.equal({});
       expect(entity.error).to.be.undefined;
       expect(entity.state.items).to.be.empty;

--- a/samples/js/js-valueentity-shopping-cart/test/shoppingcart.test.js
+++ b/samples/js/js-valueentity-shopping-cart/test/shoppingcart.test.js
@@ -22,14 +22,14 @@ describe("ShoppingCartService", () => {
   const entityId = "entityId";
 
   describe("AddItem", () => {
-    it("should respond to addItem commands", () => {
+    it("should respond to addItem commands", async () => {
       const entity = new MockValueEntity(shoppingcart, entityId);
 
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", { cartId: "cart1", productId: "a", name: "Apple", quantity: 1 });
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", { cartId: "cart1", productId: "b", name: "Banana", quantity: 2 });
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", { cartId: "cart1", productId: "c", name: "Cantaloupe", quantity: 3 });
 
       expect(entity.error).to.be.undefined;
@@ -44,12 +44,12 @@ describe("ShoppingCartService", () => {
   });
 
   describe("RemoveItem", () => {
-    it("should remove items from a cart", () => {
+    it("should remove items from a cart", async () => {
       const entity = new MockValueEntity(shoppingcart, entityId);
 
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", { cartId: "cart1", productId: "a", name: "Apple", quantity: 1 });
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", { cartId: "cart1", productId: "b", name: "Banana", quantity: 2 });
 
       expect(entity.error).to.be.undefined;
@@ -60,7 +60,7 @@ describe("ShoppingCartService", () => {
             { cartId: 'cart1', productId: 'b', name: 'Banana', quantity: 2 }
           ]);
 
-      entity.handleCommand(
+      await entity.handleCommand(
         "RemoveItem", { cartId: "cart1", productId: "a" });
       expect(entity.error).to.be.undefined;
       expect(entity.state.items)
@@ -74,7 +74,7 @@ describe("ShoppingCartService", () => {
   describe("GetCart", () => {
     it("should default to an empty cart", async () => {
       const entity = new MockValueEntity(shoppingcart, entityId);
-      const result = entity.handleCommand("GetCart", { entityId });
+      const result = await entity.handleCommand("GetCart", { entityId });
       expect(result).to.deep.equal({});
       expect(entity.error).to.be.undefined;
       expect(entity.state.items).to.be.empty;
@@ -82,15 +82,15 @@ describe("ShoppingCartService", () => {
   });
 
   describe("RemoveCart", () => {
-    it("should remove a cart", () => {
+    it("should remove a cart", async () => {
 
       const entity = new MockValueEntity(shoppingcart, entityId);
 
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", { cartId: "cart1", productId: "a", name: "Apple", quantity: 1 });
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", { cartId: "cart1", productId: "b", name: "Banana", quantity: 2 });
-      entity.handleCommand(
+      await entity.handleCommand(
         "AddItem", { cartId: "cart1", productId: "c", name: "Cantaloupe", quantity: 3 });
 
       expect(entity.error).to.be.undefined;
@@ -102,7 +102,7 @@ describe("ShoppingCartService", () => {
             { cartId: 'cart1', productId: 'c', name: 'Cantaloupe', quantity: 3 }
           ]);
 
-      entity.handleCommand(
+      await entity.handleCommand(
         "RemoveCart", { cartId: "cart1" })
       expect(entity.state.items).to.be.empty
     });

--- a/samples/js/valueentity-counter/test/counter.test.js
+++ b/samples/js/valueentity-counter/test/counter.test.js
@@ -25,28 +25,28 @@ describe("CounterService", () => {
 
   describe("Increase", () => {
 
-    it("should increase the value with no prior state", () => {
+    it("should increase the value with no prior state", async () => {
       const entity = new MockValueEntity(counter, entityId);
-      const result = entity.handleCommand("Increase", { entityId: entityId, value: 42 });
+      const result = await entity.handleCommand("Increase", { entityId: entityId, value: 42 });
 
       expect(result).to.deep.equal({});
       expect(entity.error).to.be.undefined;
       expect(entity.state).to.deep.equal(CounterState.create({ value: 42 }));
     });
 
-    it("should increase the value with some prior state", () => {
+    it("should increase the value with some prior state", async () => {
       const entity = new MockValueEntity(counter, entityId);
       entity.state = CounterState.create({ value: 13 });
-      const result = entity.handleCommand("Increase", { entityId: entityId, value: 42 });
+      const result = await entity.handleCommand("Increase", { entityId: entityId, value: 42 });
 
       expect(result).to.deep.equal({});
       expect(entity.error).to.be.undefined;
       expect(entity.state).to.deep.equal(CounterState.create({ value: 13 + 42 }));
     });
 
-    it("should fail on negative values", () => {
+    it("should fail on negative values", async () => {
       const entity = new MockValueEntity(counter, entityId);
-      const result = entity.handleCommand("Increase", { entityId: entityId, value: -2 });
+      const result = await entity.handleCommand("Increase", { entityId: entityId, value: -2 });
 
       expect(result).to.be.undefined;
       expect(entity.error).to.be.equal(`Increase requires a positive value. It was [-2].`);
@@ -54,9 +54,9 @@ describe("CounterService", () => {
   });
 
   describe("Decrease", () => {
-    it("should decrease the value with no prior state.", () => {
+    it("should decrease the value with no prior state.", async () => {
       const entity = new MockValueEntity(counter, entityId);
-      const result = entity.handleCommand("Decrease", { entityId: entityId, value: 42 });
+      const result = await entity.handleCommand("Decrease", { entityId: entityId, value: 42 });
 
       expect(result).to.deep.equal({});
       expect(entity.error).to.be.undefined;
@@ -65,10 +65,10 @@ describe("CounterService", () => {
   });
 
   describe("Reset", () => {
-    it("should reset the entity value to 0", () => {
+    it("should reset the entity value to 0", async () => {
       const entity = new MockValueEntity(counter, entityId);
       entity.state = CounterState.create({ value: 13 });
-      const result = entity.handleCommand("Reset", { entityId: entityId });
+      const result = await entity.handleCommand("Reset", { entityId: entityId });
 
       expect(result).to.deep.equal({});
       expect(entity.error).to.be.undefined;
@@ -77,10 +77,10 @@ describe("CounterService", () => {
   });
 
   describe("GetCurrentCounter", () => {
-    it("should return the current state", () => {
+    it("should return the current state", async () => {
       const entity = new MockValueEntity(counter, entityId);
       entity.state = CounterState.create({ value: 13 });
-      const result = entity.handleCommand("GetCurrentCounter", { entityId: entityId });
+      const result = await entity.handleCommand("GetCurrentCounter", { entityId: entityId });
 
       expect(result).to.deep.equal({ value: 13 });
       expect(entity.error).to.be.undefined;

--- a/samples/ts/ts-eventsourced-shopping-cart/test/shoppingcart.test.ts
+++ b/samples/ts/ts-eventsourced-shopping-cart/test/shoppingcart.test.ts
@@ -28,21 +28,21 @@ describe("ShoppingCartService", () => {
   const entityId = "entityId";
 
   describe("AddItem", () => {
-    it("should respond to addItem commands", () => {
+    it("should respond to addItem commands", async () => {
       const entity = new MockEventSourcedEntity(shoppingcart, entityId);
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "a",
         name: "Apple",
         quantity: 1
       });
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "b",
         name: "Banana",
         quantity: 2
       });
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "c",
         name: "Cantaloupe",
@@ -71,16 +71,16 @@ describe("ShoppingCartService", () => {
   });
 
   describe("RemoveItem", () => {
-    it("should remove items from a cart", () => {
+    it("should remove items from a cart", async () => {
       const entity = new MockEventSourcedEntity(shoppingcart, entityId);
 
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "a",
         name: "Apple",
         quantity: 1
       });
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "b",
         name: "Banana",
@@ -102,7 +102,7 @@ describe("ShoppingCartService", () => {
         })
       ]);
 
-      entity.handleCommand("RemoveItem", { cartId: "cart1", productId: "a" });
+      await entity.handleCommand("RemoveItem", { cartId: "cart1", productId: "a" });
       expect(entity.error).to.be.undefined;
       expect(entity.state.items).to.deep.equal([
         { productId: "b", name: "Banana", quantity: 2 }
@@ -121,9 +121,9 @@ describe("ShoppingCartService", () => {
   });
 
   describe("GetCart", () => {
-    it("should default to an empty cart", () => {
+    it("should default to an empty cart", async () => {
       const entity = new MockEventSourcedEntity(shoppingcart, entityId);
-      const result = entity.handleCommand("GetCart", { entityId });
+      const result = await entity.handleCommand("GetCart", { entityId });
       expect(result).to.deep.equal({});
       expect(entity.error).to.be.undefined;
       expect(entity.state.items).to.be.empty;

--- a/samples/ts/ts-valueentity-counter/test/counter.test.ts
+++ b/samples/ts/ts-valueentity-counter/test/counter.test.ts
@@ -24,9 +24,9 @@ describe("CounterService", () => {
   const entityId = "entityId";
 
   describe("Increase", () => {
-    it("should increase the value with no prior state", () => {
+    it("should increase the value with no prior state", async () => {
       const entity = new MockValueEntity(counterEntity, entityId);
-      const result = entity.handleCommand("Increase", {
+      const result = await entity.handleCommand("Increase", {
         entityId: entityId,
         value: 42
       });
@@ -36,10 +36,10 @@ describe("CounterService", () => {
       expect(entity.state).to.deep.equal(CounterState.create({ value: 42 }));
     });
 
-    it("should increase the value with some prior state", () => {
+    it("should increase the value with some prior state", async () => {
       const entity = new MockValueEntity(counterEntity, entityId);
       entity.state = CounterState.create({ value: 13 });
-      const result = entity.handleCommand("Increase", {
+      const result = await entity.handleCommand("Increase", {
         entityId: entityId,
         value: 42
       });
@@ -49,9 +49,9 @@ describe("CounterService", () => {
       expect(entity.state).to.deep.equal(CounterState.create({ value: 13 + 42 }));
     });
 
-    it("should fail on negative values", () => {
+    it("should fail on negative values", async () => {
       const entity = new MockValueEntity(counterEntity, entityId);
-      const result = entity.handleCommand("Increase", {
+      const result = await entity.handleCommand("Increase", {
         entityId: entityId,
         value: -2
       });
@@ -62,9 +62,9 @@ describe("CounterService", () => {
   });
 
   describe("Decrease", () => {
-    it("should decrease the value with no prior state.", () => {
+    it("should decrease the value with no prior state.", async () => {
       const entity = new MockValueEntity(counterEntity, entityId);
-      const result = entity.handleCommand("Decrease", {
+      const result = await entity.handleCommand("Decrease", {
         entityId: entityId,
         value: 42
       });
@@ -76,10 +76,10 @@ describe("CounterService", () => {
   });
 
   describe("Reset", () => {
-    it("should reset the entity value to 0", () => {
+    it("should reset the entity value to 0", async () => {
       const entity = new MockValueEntity(counterEntity, entityId);
       entity.state = CounterState.create({ value: 13 });
-      const result = entity.handleCommand("Reset", { entityId: entityId });
+      const result = await entity.handleCommand("Reset", { entityId: entityId });
 
       expect(result).to.deep.equal({});
       expect(entity.error).to.be.undefined;
@@ -88,10 +88,10 @@ describe("CounterService", () => {
   });
 
   describe("GetCurrentCounter", () => {
-    it("should return the current state", () => {
+    it("should return the current state", async () => {
       const entity = new MockValueEntity(counterEntity, entityId);
       entity.state = CounterState.create({ value: 13 });
-      const result = entity.handleCommand("GetCurrentCounter", {
+      const result = await entity.handleCommand("GetCurrentCounter", {
         entityId: entityId
       });
 

--- a/samples/ts/ts-valueentity-shopping-cart/test/shoppingcart.test.ts
+++ b/samples/ts/ts-valueentity-shopping-cart/test/shoppingcart.test.ts
@@ -22,22 +22,22 @@ describe("ShoppingCartService", () => {
   const entityId = "entityId";
 
   describe("AddItem", () => {
-    it("should respond to addItem commands", () => {
+    it("should respond to addItem commands", async () => {
       const entity = new MockValueEntity(shoppingcart, entityId);
 
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "a",
         name: "Apple",
         quantity: 1
       });
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "b",
         name: "Banana",
         quantity: 2
       });
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "c",
         name: "Cantaloupe",
@@ -54,16 +54,16 @@ describe("ShoppingCartService", () => {
   });
 
   describe("RemoveItem", () => {
-    it("should remove items from a cart", () => {
+    it("should remove items from a cart", async () => {
       const entity = new MockValueEntity(shoppingcart, entityId);
 
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "a",
         name: "Apple",
         quantity: 1
       });
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "b",
         name: "Banana",
@@ -76,7 +76,7 @@ describe("ShoppingCartService", () => {
         { cartId: "cart1", productId: "b", name: "Banana", quantity: 2 }
       ]);
 
-      entity.handleCommand("RemoveItem", { cartId: "cart1", productId: "a" });
+      await entity.handleCommand("RemoveItem", { cartId: "cart1", productId: "a" });
       expect(entity.error).to.be.undefined;
       expect(entity.state.items).to.deep.equal([
         { cartId: "cart1", productId: "b", name: "Banana", quantity: 2 }
@@ -87,7 +87,7 @@ describe("ShoppingCartService", () => {
   describe("GetCart", () => {
     it("should default to an empty cart", async () => {
       const entity = new MockValueEntity(shoppingcart, entityId);
-      const result = entity.handleCommand("GetCart", { entityId });
+      const result = await entity.handleCommand("GetCart", { entityId });
       expect(result).to.deep.equal({});
       expect(entity.error).to.be.undefined;
       expect(entity.state.items).to.be.empty;
@@ -95,22 +95,22 @@ describe("ShoppingCartService", () => {
   });
 
   describe("RemoveCart", () => {
-    it("should remove a cart", () => {
+    it("should remove a cart", async () => {
       const entity = new MockValueEntity(shoppingcart, entityId);
 
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "a",
         name: "Apple",
         quantity: 1
       });
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "b",
         name: "Banana",
         quantity: 2
       });
-      entity.handleCommand("AddItem", {
+      await entity.handleCommand("AddItem", {
         cartId: "cart1",
         productId: "c",
         name: "Cantaloupe",
@@ -124,7 +124,7 @@ describe("ShoppingCartService", () => {
         { cartId: "cart1", productId: "c", name: "Cantaloupe", quantity: 3 }
       ]);
 
-      entity.handleCommand("RemoveCart", { cartId: "cart1" });
+      await entity.handleCommand("RemoveCart", { cartId: "cart1" });
       expect(entity.state.items).to.be.empty;
     });
   });

--- a/testkit/example/proto/example.proto
+++ b/testkit/example/proto/example.proto
@@ -16,7 +16,6 @@ syntax = "proto3";
 
 package com.example;
 
-import "google/protobuf/any.proto";
 import "kalix/annotations.proto";
 
 message ExampleState {

--- a/testkit/example/types/event-sourced-entity.d.ts
+++ b/testkit/example/types/event-sourced-entity.d.ts
@@ -55,17 +55,17 @@ export declare namespace ExampleEventSourcedEntityService {
       command: api.In,
       state: State,
       ctx: CommandContext,
-    ) => CommandReply<api.IOut>;
+    ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
     DoSomethingTwo: (
       command: api.In,
       state: State,
       ctx: CommandContext,
-    ) => Promise<CommandReply<api.IOut>>;
+    ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
     Fail: (
       command: api.In,
       state: State,
       ctx: CommandContext,
-    ) => CommandReply<api.IOut>;
+    ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
   };
 }
 

--- a/testkit/example/types/value-entity.d.ts
+++ b/testkit/example/types/value-entity.d.ts
@@ -39,17 +39,17 @@ export declare namespace ExampleValueEntityService {
       command: api.In,
       state: State,
       ctx: CommandContext,
-    ) => CommandReply<api.IOut>;
+    ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
     DoSomethingTwo: (
       command: api.In,
       state: State,
       ctx: CommandContext,
-    ) => Promise<CommandReply<api.IOut>>;
+    ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
     Fail: (
       command: api.In,
       state: State,
       ctx: CommandContext,
-    ) => CommandReply<api.IOut>;
+    ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
   };
 }
 

--- a/testkit/package-lock.json
+++ b/testkit/package-lock.json
@@ -120,16 +120,6 @@
         }
       }
     },
-    "@kalix-io/kalix-scripts": {
-      "version": "1.0.0-M8",
-      "resolved": "https://registry.npmjs.org/@kalix-io/kalix-scripts/-/kalix-scripts-1.0.0-M8.tgz",
-      "integrity": "sha512-bbXIU/20SbnieuDxNaOBbdXS/3APUH6MYjTxPyPkvEVE47ervVQC0j6V2E576BZz3ItUbYjUvidkTftk3pITMw==",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "^7.0.3",
-        "node-fetch": "^2.6.1"
-      }
-    },
     "@mapbox/node-pre-gyp": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.9.tgz",
@@ -780,17 +770,6 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true
     },
-    "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      }
-    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -1195,12 +1174,6 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
-    },
     "js-yaml": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
@@ -1589,12 +1562,6 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
-    "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
-    },
     "pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -1746,21 +1713,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
       "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
-      "dev": true
-    },
-    "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "^3.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
     "signal-exit": {
@@ -2076,15 +2028,6 @@
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
-      }
-    },
-    "which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "requires": {
-        "isexe": "^2.0.0"
       }
     },
     "wide-align": {

--- a/testkit/src/mock-event-sourced-entity.ts
+++ b/testkit/src/mock-event-sourced-entity.ts
@@ -60,13 +60,13 @@ export class MockEventSourcedEntity<Entity extends EventSourcedEntity> {
    * @param ctx - override the context object for this handler for advanced behaviour
    * @returns the result of the command
    */
-  handleCommand(
+  async handleCommand(
     commandName: MockEventSourcedEntity.CommandNames<Entity>,
     command: any,
     ctx = new MockEventSourcedEntity.CommandContext<
       MockEventSourcedEntity.EventsType<Entity>
     >(this.entityId),
-  ): any {
+  ): Promise<any> {
     const behavior = this.entity.behavior
       ? this.entity.behavior(this.state)
       : { commandHandlers: {} };
@@ -79,7 +79,7 @@ export class MockEventSourcedEntity<Entity extends EventSourcedEntity> {
       grpcMethod.requestSerialize(command),
     );
 
-    const reply = handler(request, this.state, ctx);
+    const reply = await handler(request, this.state, ctx);
     const message = reply instanceof Reply ? reply.getMessage() : reply;
 
     ctx.events.forEach((event) => this.handleEvent(event));

--- a/testkit/src/mock-value-entity.ts
+++ b/testkit/src/mock-value-entity.ts
@@ -52,20 +52,20 @@ export class MockValueEntity<Entity extends ValueEntity> {
   }
 
   /**
-   * Handle the provided command, and return the result. Any emitted events are also handled.
+   * Handle the provided command, and return the result.
    *
    * @param commandName - the command method name (as per the entity proto definition)
    * @param command - the command message
    * @param ctx - override the context object for this handler for advanced behaviour
    * @returns the result of the command
    */
-  handleCommand(
+  async handleCommand(
     commandName: MockValueEntity.CommandNames<Entity>,
     command: any,
     ctx = new MockValueEntity.CommandContext<MockValueEntity.StateType<Entity>>(
       this.entityId,
     ),
-  ): any {
+  ): Promise<any> {
     const handler = (
       this.entity.commandHandlers as MockValueEntity.CommandHandlersType<Entity>
     )[commandName];
@@ -75,7 +75,7 @@ export class MockValueEntity<Entity extends ValueEntity> {
       grpcMethod.requestSerialize(command),
     );
 
-    const reply = handler(request, this.state, ctx);
+    const reply = await handler(request, this.state, ctx);
     const message = reply instanceof Reply ? reply.getMessage() : reply;
 
     if (ctx.delete) {
@@ -115,7 +115,7 @@ export namespace MockValueEntity {
    *
    * By default, calls to {@link MockValueEntity.handleCommand} will
    * construct their own instance of this class, however for making assertions on
-   * forwarding or emmitted effects you may provide your own.
+   * forwarding or emitted effects you may provide your own.
    */
   export class CommandContext<State extends Serializable = any>
     extends MockCommandContext

--- a/testkit/test/mock-event-sourced-entity.test.ts
+++ b/testkit/test/mock-event-sourced-entity.test.ts
@@ -27,7 +27,7 @@ const ExampleEventTwo = eventSourcedEntity.lookupType(
 );
 
 describe('MockEventSourcedEntity', () => {
-  it('should update state', () => {
+  it('should update state', async () => {
     const entity = new MockEventSourcedEntity(eventSourcedEntity, 'entity-id');
 
     expect(entity.error).to.be.undefined;
@@ -41,23 +41,35 @@ describe('MockEventSourcedEntity', () => {
       ExampleState.create({ field1: 'foo', field2: 'bar' }),
     );
 
-    const response = entity.handleCommand('DoSomethingOne', {
+    const responseOne = await entity.handleCommand('DoSomethingOne', {
       field: 'baz',
     });
 
-    expect(response).to.deep.equal({
+    expect(responseOne).to.deep.equal({
       field: 'EventSourcedEntity received: baz',
     });
     expect(entity.error).to.be.undefined;
     expect(entity.state).to.deep.equal(
       ExampleState.create({ field1: 'baz', field2: 'bar' }),
     );
+
+    const responseTwo = await entity.handleCommand('DoSomethingTwo', {
+      field: 'qux',
+    });
+
+    expect(responseTwo).to.deep.equal({
+      field: 'EventSourcedEntity async received: qux',
+    });
+    expect(entity.error).to.be.undefined;
+    expect(entity.state).to.deep.equal(
+      ExampleState.create({ field1: 'baz', field2: 'qux' }),
+    );
   });
 
-  it('should record error message', () => {
+  it('should record error message', async () => {
     const entity = new MockEventSourcedEntity(eventSourcedEntity, 'entity-id');
 
-    const response = entity.handleCommand('Fail', {});
+    const response = await entity.handleCommand('Fail', {});
 
     expect(response).to.be.undefined;
     expect(entity.error).to.equal('some-error');

--- a/testkit/test/mock-value-entity.test.ts
+++ b/testkit/test/mock-value-entity.test.ts
@@ -21,27 +21,39 @@ import valueEntity from '../example/src/value-entity';
 const ExampleState = valueEntity.lookupType('com.example.ExampleState');
 
 describe('MockValueEntity', () => {
-  it('should update state', () => {
+  it('should update state', async () => {
     const entity = new MockValueEntity(valueEntity, 'entity-id');
 
     expect(entity.error).to.be.undefined;
     expect(entity.state).to.deep.equal(ExampleState.create({}));
 
-    const response = entity.handleCommand('DoSomethingOne', {
+    const responseOne = await entity.handleCommand('DoSomethingOne', {
       field: 'foo',
     });
 
-    expect(response).to.deep.equal({ field: 'ValueEntity received: foo' });
+    expect(responseOne).to.deep.equal({ field: 'ValueEntity received: foo' });
     expect(entity.error).to.be.undefined;
     expect(entity.state).to.deep.equal(
       ExampleState.create({ field1: 'foo', field2: '' }),
     );
+
+    const responseTwo = await entity.handleCommand('DoSomethingTwo', {
+      field: 'bar',
+    });
+
+    expect(responseTwo).to.deep.equal({
+      field: 'ValueEntity async received: bar',
+    });
+    expect(entity.error).to.be.undefined;
+    expect(entity.state).to.deep.equal(
+      ExampleState.create({ field1: 'foo', field2: 'bar' }),
+    );
   });
 
-  it('should record error message', () => {
+  it('should record error message', async () => {
     const entity = new MockValueEntity(valueEntity, 'entity-id');
 
-    const response = entity.handleCommand('Fail', {});
+    const response = await entity.handleCommand('Fail', {});
 
     expect(response).to.be.undefined;
     expect(entity.error).to.equal('some-error');


### PR DESCRIPTION
Entity command handlers can already be async. Add support for this to the codegen and testkit.

Testkit hasn't been published yet, so not exactly breaking, but `handleCommand` in the mock entities is now async. If we wanted to make it compatible with what was there before, we could also have two versions of mocked command handling, where the sync version throws if the command handler returns a Promise. But simpler to just have one method, explicitly async.