### PR TITLE
Acl support

### DIFF
--- a/docs/src/modules/javascript/nav.adoc
+++ b/docs/src/modules/javascript/nav.adoc
@@ -12,4 +12,5 @@
 *** xref:javascript:actions-publishing-subscribing.adoc[Publishing and Subscribing]
 *** xref:javascript:serialization.adoc[Handling Serialization]
 *** xref:javascript:call-another-service.adoc[Calling other services]
+*** xref:access-control.adoc[Access Control Lists (ACLs)]
 *** xref:javascript:api.adoc[JavaScript API docs]

--- a/docs/src/modules/javascript/pages/access-control.adoc
+++ b/docs/src/modules/javascript/pages/access-control.adoc
@@ -35,10 +35,8 @@ In the unit test Mock components, the ACLs are ignored.
 
 == ACLs when running integration tests
 
-FIXME not implemented yet
+When running integration tests, ACLs are enabled by default but can be explicitly disabled per test by running the test with `IntegrationTestKitOptions` setting `aclCheckingEnabled` to `true`.
 
-When running integration tests, ACLs are enabled by default but can be explicitly disabled per test by running the test with `Settings.withAclDisabled`.
+For integration tests that call other services that have ACLs limiting access to specific service names `IntegrationTestKitOptions.withServiceName` allows specifying what the service identifies itself as to other services.
 
-For integration tests that call other services that have ACLs limiting access to specific service names `Settings.withServiceName` allows specifying what the service identifies itself as to other services.
-
-`KalixTestKit.getGrpcClientForPrincipal` makes it possible to get a integration test client that is authenticated with specific credentials for calling a service with ACLs.
+`IntegrationTestkit.clientsForPrincipal` makes it possible to get a integration test client that is authenticated with specific credentials for calling a service with ACLs.

--- a/docs/src/modules/javascript/pages/access-control.adoc
+++ b/docs/src/modules/javascript/pages/access-control.adoc
@@ -24,7 +24,6 @@ This is the default ACL included in the quickstarts and project templates, it al
 
 == Inspecting the principal inside a service
 
-FIXME not implemented yet
 
 Checking the ACLs are in general done for you by Kalix, however in some cases programmatic access to the principal of a call can be useful.
 
@@ -32,7 +31,7 @@ Accessing the principal of a call inside of a service is possible through the re
 
 == ACLs when running unit tests
 
-In the generated unit test testkits, the ACLs are ignored.
+In the unit test Mock components, the ACLs are ignored.
 
 == ACLs when running integration tests
 

--- a/docs/src/modules/javascript/pages/access-control.adoc
+++ b/docs/src/modules/javascript/pages/access-control.adoc
@@ -1,0 +1,45 @@
+= Access Control Lists (ACLs)
+
+This section describes functionality in the JavaScript/TypeScript SDK related to ACLs (Access Control Lists), for information about how the ACLs are defined and control access see https://docs.kalix.io/services/using-acls.html[Using ACLs]
+
+== Default ACL in project templates
+
+If no ACLs is defined at all in a Kalix service Kalix will allow requests from both other services and the internet to all components of a Kalix service.
+
+The Kalix quickstarts include a less permissive ACL for the entire service, to not accidentally make services available to the public internet, just like the one described in the next section.
+
+== Defining an ACL for the entire Kalix Service
+
+A default ACL for the entire Kalix Service can be defined by placing a `kalix_policy.proto` file among the protobuf descriptors of the service, and including it in your build. It should only contain a `kalix.file(acl)` annotation:
+
+[source,proto,indent=0]
+.proto/com/example/kalix_policy.proto
+----
+include::example$js-doc-snippets/proto/com/example/kalix_policy.proto[tag=default]
+----
+<1> Import the needed Kalix annotations from `kalix/annotations.proto`
+<2> Allow access from all other services, but not the public internet
+
+This is the default ACL included in the quickstarts and project templates, it allows calls from any other Kalix service deployed in the same project, but denies access from the internet.
+
+== Inspecting the principal inside a service
+
+FIXME not implemented yet
+
+Checking the ACLs are in general done for you by Kalix, however in some cases programmatic access to the principal of a call can be useful.
+
+Accessing the principal of a call inside of a service is possible through the request metadata `Metadata.principals()`. The `Metadata` for a call is available through the context (`actionContext`, `commandContext`) of the component.
+
+== ACLs when running unit tests
+
+In the generated unit test testkits, the ACLs are ignored.
+
+== ACLs when running integration tests
+
+FIXME not implemented yet
+
+When running integration tests, ACLs are enabled by default but can be explicitly disabled per test by running the test with `Settings.withAclDisabled`.
+
+For integration tests that call other services that have ACLs limiting access to specific service names `Settings.withServiceName` allows specifying what the service identifies itself as to other services.
+
+`KalixTestKit.getGrpcClientForPrincipal` makes it possible to get a integration test client that is authenticated with specific credentials for calling a service with ACLs.

--- a/docs/src/modules/javascript/pages/access-control.adoc
+++ b/docs/src/modules/javascript/pages/access-control.adoc
@@ -1,16 +1,16 @@
 = Access Control Lists (ACLs)
 
-This section describes functionality in the JavaScript/TypeScript SDK related to ACLs (Access Control Lists), for information about how the ACLs are defined and control access see https://docs.kalix.io/services/using-acls.html[Using ACLs]
+This section describes functionality in the JavaScript/TypeScript SDK related to ACLs (Access Control Lists), for information about how the ACLs are defined and control access see https://docs.kalix.io/services/using-acls.html[Using ACLs].
 
 == Default ACL in project templates
 
-If no ACLs is defined at all in a Kalix service Kalix will allow requests from both other services and the internet to all components of a Kalix service.
+If no ACLs are defined at all in a Kalix service, Kalix will allow requests from both other services and the internet to all components of the Kalix service.
 
 The Kalix quickstarts include a less permissive ACL for the entire service, to not accidentally make services available to the public internet, just like the one described in the next section.
 
 == Defining an ACL for the entire Kalix Service
 
-A default ACL for the entire Kalix Service can be defined by placing a `kalix_policy.proto` file among the protobuf descriptors of the service, and including it in your build. It should only contain a `kalix.file(acl)` annotation:
+A default ACL for the entire Kalix Service can be defined by placing a `kalix_policy.proto` file among the protobuf descriptors of the service, and including it in your build. It should only contain a `(kalix.file).acl` annotation:
 
 [source,proto,indent=0]
 .proto/com/example/kalix_policy.proto
@@ -25,7 +25,7 @@ This is the default ACL included in the quickstarts and project templates, it al
 == Inspecting the principal inside a service
 
 
-Checking the ACLs are in general done for you by Kalix, however in some cases programmatic access to the principal of a call can be useful.
+Checking the ACLs is generally done for you by Kalix, however in some cases programmatic access to the principal of a call can be useful.
 
 Accessing the principal of a call inside of a service is possible through the request metadata `Metadata.principals()`. The `Metadata` for a call is available through the context (`actionContext`, `commandContext`) of the component.
 
@@ -35,8 +35,8 @@ In the unit test Mock components, the ACLs are ignored.
 
 == ACLs when running integration tests
 
-When running integration tests, ACLs are enabled by default but can be explicitly disabled per test by running the test with `IntegrationTestKitOptions` setting `aclCheckingEnabled` to `true`.
+When running integration tests, ACLs are enabled by default but can be explicitly disabled per test by running the test with `IntegrationTestKitOptions` setting `aclCheckingEnabled` to `false`.
 
 For integration tests that call other services that have ACLs limiting access to specific service names `IntegrationTestKitOptions.withServiceName` allows specifying what the service identifies itself as to other services.
 
-`IntegrationTestkit.clientsForPrincipal` makes it possible to get a integration test client that is authenticated with specific credentials for calling a service with ACLs.
+`IntegrationTestkit.clientsForPrincipal` makes it possible to get an integration test client that is authenticated with specific credentials for calling a service with ACLs.

--- a/docs/src/modules/javascript/pages/call-another-service.adoc
+++ b/docs/src/modules/javascript/pages/call-another-service.adoc
@@ -24,18 +24,20 @@ include::example$js-doc-snippets/proto/com/example/counter_api.proto[tag=other-s
 
 The proto-js tool will now generate a client for the service in `lib/generated/proto.js` when we compile the project.
 
-Creating an instance of the generated client is done through the `.grpc` object on the action.
+Creating an instance of the generated client is done through the `.clients` object on the action.
 In our delegating service implementation:
 
 [source,javascript,indent=0]
-.src/main/java/com/example/delegatingservice.js
+.src/delegatingservice.js
 ----
 include::example$js-doc-snippets/src/delegatingservice.js[tag=delegating-action]
 ----
 <1> Include the `proto` file of the other service in the action service descriptors.
 <2> Create the client using the provided creators to get async methods. Defaults to a cleartext connection as TLS is handled transparently for us.
-<3> Use the name that the other Kalix service was deployed as, in this case `counter` and port `80`.
+<3> Use the name that the other Kalix service was deployed as, in this case `counter`.
 <4> We can now call the various methods on the other service with their method names directly on the client. The calls return promises so we can use `await/async` to interact with them.
+
+**Note:** The client can only be created once the service has been started by Kalix, for example triggered by a call, not from the constructor.
 
 == External gRPC services
 

--- a/docs/src/modules/javascript/pages/call-another-service.adoc
+++ b/docs/src/modules/javascript/pages/call-another-service.adoc
@@ -37,7 +37,7 @@ include::example$js-doc-snippets/src/delegatingservice.js[tag=delegating-action]
 <3> Use the name that the other Kalix service was deployed as, in this case `counter`.
 <4> We can now call the various methods on the other service with their method names directly on the client. The calls return promises so we can use `await/async` to interact with them.
 
-**Note:** The client can only be created once the service has been started by Kalix, for example triggered by a call, not from the constructor.
+NOTE: The client can only be created once the service has been started by Kalix, for example triggered by a call, not from the constructor.
 
 == External gRPC services
 

--- a/samples/js/js-customer-registry/customer_api.proto
+++ b/samples/js/js-customer-registry/customer_api.proto
@@ -46,7 +46,7 @@ message ChangeAddressRequest {
 }
 
 service CustomerService {
-  option (kalix.method).acl.allow = { principal: ALL };
+  option (kalix.service).acl.allow = { principal: ALL };
 
   rpc Create(Customer) returns (google.protobuf.Empty) {}
 

--- a/samples/js/js-customer-registry/customer_api.proto
+++ b/samples/js/js-customer-registry/customer_api.proto
@@ -46,6 +46,8 @@ message ChangeAddressRequest {
 }
 
 service CustomerService {
+  option (kalix.method).acl.allow = { principal: ALL };
+
   rpc Create(Customer) returns (google.protobuf.Empty) {}
 
   rpc ChangeName(ChangeNameRequest) returns (google.protobuf.Empty) {}

--- a/samples/js/js-customer-registry/customer_view.proto
+++ b/samples/js/js-customer-registry/customer_view.proto
@@ -25,6 +25,10 @@ import "google/protobuf/any.proto";
 
 // tag::service[]
 service CustomerByName {
+  // end::service[]
+  option (kalix.method).acl.allow = { principal: ALL };
+  // tag::service[]
+
   rpc UpdateCustomer(domain.CustomerState) returns (domain.CustomerState) { // <1>
     option (kalix.method).eventing.in = { // <2>
       value_entity: "customers"

--- a/samples/js/js-customer-registry/customer_view.proto
+++ b/samples/js/js-customer-registry/customer_view.proto
@@ -26,7 +26,7 @@ import "google/protobuf/any.proto";
 // tag::service[]
 service CustomerByName {
   // end::service[]
-  option (kalix.method).acl.allow = { principal: ALL };
+  option (kalix.service).acl.allow = { principal: ALL };
   // tag::service[]
 
   rpc UpdateCustomer(domain.CustomerState) returns (domain.CustomerState) { // <1>

--- a/samples/js/js-customer-registry/kalix_policy.proto
+++ b/samples/js/js-customer-registry/kalix_policy.proto
@@ -1,3 +1,17 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This is the default ACLs for all components of this Kalix Service
 syntax = "proto3";
 

--- a/samples/js/js-customer-registry/kalix_policy.proto
+++ b/samples/js/js-customer-registry/kalix_policy.proto
@@ -1,0 +1,11 @@
+// This is the default ACLs for all components of this Kalix Service
+syntax = "proto3";
+
+package com.example;
+
+import "kalix/annotations.proto";
+
+// only allow access from other services in the same project by default
+option (kalix.file).acl = {
+  allow: { service: "*" }
+};

--- a/samples/js/js-customer-registry/package.json
+++ b/samples/js/js-customer-registry/package.json
@@ -30,7 +30,7 @@
     "mocha": "^10.0.0"
   },
   "scripts": {
-    "build": "compile-descriptor customer_api.proto customer_domain.proto customer_view.proto",
+    "build": "compile-descriptor customer_api.proto customer_domain.proto customer_view.proto kalix_policy.proto",
     "pretest": "npm run build",
     "test": "mocha",
     "preintegration-test": "npm run build",

--- a/samples/js/js-doc-snippets/proto/com/example/kalix_policy.proto
+++ b/samples/js/js-doc-snippets/proto/com/example/kalix_policy.proto
@@ -1,0 +1,12 @@
+// This is the default ACLs for all components of this Kalix Service
+// tag::default[]
+syntax = "proto3";
+
+package com.example;
+
+import "kalix/annotations.proto"; // <1>
+
+option (kalix.file).acl = {
+  allow: { service: "*" } // <2>
+};
+// end::default[]

--- a/samples/js/js-doc-snippets/src/delegatingservice.js
+++ b/samples/js/js-doc-snippets/src/delegatingservice.js
@@ -47,26 +47,34 @@ const action = new Action(
   }
 );
 
-const counterClient = action.clients.com.example.CounterService.createClient( // <2>
-  "counter:80" // <3>
-);
-
-// end::delegating-action[]
-{
-// tag::public-grpc[]
-const counterClient = action.clients.com.example.CounterService.createClient( // <2>
-  "still-queen-1447.us-east1.apps.kalix.dev", // <3>
-  grpc.credentials.createSsl() // <4>
-);
-// end::public-grpc[]
-}
-// tag::delegating-action[]
-
+// tag::other-component[]
 action.commandHandlers = {
   async AddAndReturn(request) {
+    // end::delegating-action[]
+    // end::other-component[]
+    {
+      // FIXME not used in docs yet
+      // tag::other-component[]
+      const counterClient = action.clients.com.example.CounterService.createClient(); // <1>
+      // end::other-component[]
+    }
+
+    {
+    // tag::public-grpc[]
+      const counterClient = action.clients.com.example.CounterService.createClient( // <2>
+        "still-queen-1447.us-east1.apps.kalix.dev", // <3>
+        grpc.credentials.createSsl() // <4>
+      );
+    // end::public-grpc[]
+    }
+    // tag::delegating-action[]
+    const counterClient = action.clients.com.example.CounterService.createClient( // <2>
+      "counter" // <3>
+    );
     await counterClient.increase({counterId: request.counterId, value: 1}); // <4>
-    const currentCounter = await counterClient.getCurrentCounter({counterId: request.counterId });
-    return replies.message({value: currentCounter.value });
+    const currentCounter = await counterClient.getCurrentCounter({counterId: request.counterId});
+    return replies.message({value: currentCounter.value});
+
   }
 };
 

--- a/samples/ts/ts-customer-registry/customer_api.proto
+++ b/samples/ts/ts-customer-registry/customer_api.proto
@@ -46,7 +46,7 @@ message ChangeAddressRequest {
 }
 
 service CustomerService {
-  option (kalix.method).acl.allow = { principal: ALL };
+  option (kalix.service).acl.allow = { principal: ALL };
 
   rpc Create(Customer) returns (google.protobuf.Empty) {}
 

--- a/samples/ts/ts-customer-registry/customer_api.proto
+++ b/samples/ts/ts-customer-registry/customer_api.proto
@@ -46,6 +46,8 @@ message ChangeAddressRequest {
 }
 
 service CustomerService {
+  option (kalix.method).acl.allow = { principal: ALL };
+
   rpc Create(Customer) returns (google.protobuf.Empty) {}
 
   rpc ChangeName(ChangeNameRequest) returns (google.protobuf.Empty) {}

--- a/samples/ts/ts-customer-registry/customer_view.proto
+++ b/samples/ts/ts-customer-registry/customer_view.proto
@@ -25,7 +25,7 @@ import "kalix/annotations.proto";
 // tag::service[]
 service CustomerByName {
   // end::service[]
-  option (kalix.method).acl.allow = { principal: ALL };
+  option (kalix.service).acl.allow = { principal: ALL };
   // tag::service[]
   rpc UpdateCustomer(domain.CustomerState) returns (domain.CustomerState) { // <1>
     option (kalix.method).eventing.in = { // <2>

--- a/samples/ts/ts-customer-registry/customer_view.proto
+++ b/samples/ts/ts-customer-registry/customer_view.proto
@@ -24,6 +24,9 @@ import "kalix/annotations.proto";
 
 // tag::service[]
 service CustomerByName {
+  // end::service[]
+  option (kalix.method).acl.allow = { principal: ALL };
+  // tag::service[]
   rpc UpdateCustomer(domain.CustomerState) returns (domain.CustomerState) { // <1>
     option (kalix.method).eventing.in = { // <2>
       value_entity: "customers"

--- a/samples/ts/ts-customer-registry/kalix_policy.proto
+++ b/samples/ts/ts-customer-registry/kalix_policy.proto
@@ -1,3 +1,17 @@
+// Copyright 2021 Lightbend Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // This is the default ACLs for all components of this Kalix Service
 syntax = "proto3";
 

--- a/samples/ts/ts-customer-registry/kalix_policy.proto
+++ b/samples/ts/ts-customer-registry/kalix_policy.proto
@@ -1,0 +1,11 @@
+// This is the default ACLs for all components of this Kalix Service
+syntax = "proto3";
+
+package com.example;
+
+import "kalix/annotations.proto";
+
+// only allow access from other services in the same project by default
+option (kalix.file).acl = {
+  allow: { service: "*" }
+};

--- a/samples/ts/ts-customer-registry/package.json
+++ b/samples/ts/ts-customer-registry/package.json
@@ -47,7 +47,7 @@
     "compile-customer-api-proto": "mkdirp lib/generated && pbjs -t static-module -w commonjs --no-encode --no-decode --no-verify --no-convert --no-delimited customer_api.proto -o lib/generated/customer_api.js && pbts --no-comments -o lib/generated/customer_api.d.ts lib/generated/customer_api.js",
     "compile-customer-domain-proto": "mkdirp lib/generated && pbjs -t static-module -w commonjs --no-encode --no-decode --no-verify --no-convert --no-delimited customer_domain.proto -o lib/generated/customer_domain.js && pbts --no-comments -o lib/generated/customer_domain.d.ts lib/generated/customer_domain.js",
     "compile-customer-view-proto": "mkdirp lib/generated && pbjs -t static-module -w commonjs --no-encode --no-decode --no-verify --no-convert --no-delimited customer_view.proto -o lib/generated/customer_view.js && pbts --no-comments -o lib/generated/customer_view.d.ts lib/generated/customer_view.js",
-    "build": "compile-descriptor customer_api.proto customer_domain.proto customer_view.proto && npm run compile-customer-api-proto && npm run compile-customer-domain-proto && npm run compile-customer-view-proto && tsc",
+    "build": "compile-descriptor customer_api.proto customer_domain.proto customer_view.proto kalix_policy.proto && npm run compile-customer-api-proto && npm run compile-customer-domain-proto && npm run compile-customer-view-proto && tsc",
     "pretest": "npm run build",
     "test": "ts-mocha",
     "preintegration-test": "npm run build",

--- a/sdk/config.json
+++ b/sdk/config.json
@@ -1,3 +1,3 @@
 {
-  "frameworkVersion": "1.0.6"
+  "frameworkVersion": "1.0.10"
 }

--- a/sdk/src/event-sourced-entity.ts
+++ b/sdk/src/event-sourced-entity.ts
@@ -18,7 +18,7 @@ import * as protobufHelper from './protobuf-helper';
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import EventSourcedEntityServices from './event-sourced-entity-support';
-import { Entity, EntityOptions, ServiceMap } from './kalix';
+import { Entity, EntityOptions, PreStartSettings, ServiceMap } from './kalix';
 import { GrpcClientLookup, GrpcUtil } from './grpc-util';
 import { Serializable } from './serializable';
 import { EntityCommandContext, CommandReply } from './command';
@@ -272,7 +272,7 @@ export class EventSourcedEntity<
   readonly serviceName: string;
   readonly service: protobuf.Service;
   readonly options: Required<EventSourcedEntity.Options>;
-  readonly clients: GrpcClientLookup;
+  clients?: GrpcClientLookup;
 
   /** @internal */ readonly root: protobuf.Root;
   /** @internal */ readonly grpc: grpc.GrpcObject;
@@ -337,7 +337,17 @@ export class EventSourcedEntity<
 
     this.grpc = grpc.loadPackageDefinition(packageDefinition);
 
-    this.clients = GrpcUtil.clientCreators(this.root, this.grpc);
+    this.clients = undefined;
+  }
+
+  preStart(settings: PreStartSettings): void {
+    this.clients = GrpcUtil.clientCreators(
+      this.root,
+      this.grpc,
+      settings.proxyHostname,
+      settings.proxyPort,
+      settings.identificationInfo,
+    );
   }
 
   /** @internal */

--- a/sdk/src/grpc-util.ts
+++ b/sdk/src/grpc-util.ts
@@ -192,11 +192,11 @@ export class GrpcUtil {
         // unary and streaming out
         // important: rebind 'this' of the original/patched method
         const reboundOriginalMethod = originalMethod.bind(client);
-        const patchedMethod = function(
-            arg: any,
-            metadata: grpc.Metadata,
-            options: grpc.CallOptions,
-            callback: grpc.requestCallback<any>,
+        const patchedMethod = function (
+          arg: any,
+          metadata: grpc.Metadata,
+          options: grpc.CallOptions,
+          callback: grpc.requestCallback<any>,
         ) {
           if (!metadata) {
             metadata = metadataWithHeaders;

--- a/sdk/src/grpc-util.ts
+++ b/sdk/src/grpc-util.ts
@@ -82,13 +82,18 @@ export class GrpcUtil {
     identificationInfo?: IdentificationInfo,
   ): GrpcClientLookup {
     const result: GrpcClientLookup = {};
-    const selfAuthHeaders = new grpc.Metadata();
-    const otherKalixServiceAuthHeaders = new grpc.Metadata();
-    if (identificationInfo) {
+    let selfAuthHeaders: grpc.Metadata | undefined;
+    let otherKalixServiceAuthHeaders: grpc.Metadata | undefined;
+    if (identificationInfo?.selfIdentificationHeader) {
+      selfAuthHeaders = new grpc.Metadata();
       selfAuthHeaders.add(
         identificationInfo.selfIdentificationHeader!,
         identificationInfo.selfIdentificationToken!,
       );
+    }
+    if (identificationInfo?.serviceIdentificationHeader) {
+      // only set for local dev proxy
+      otherKalixServiceAuthHeaders = new grpc.Metadata();
       otherKalixServiceAuthHeaders.add(
         identificationInfo.serviceIdentificationHeader!,
         identificationInfo.selfDeploymentName!,
@@ -146,13 +151,15 @@ export class GrpcUtil {
         if (identificationInfo) {
           switch (serviceType) {
             case ServiceType.SELF:
-              GrpcUtil.addHeadersToAllRequests(client, selfAuthHeaders);
+              if (selfAuthHeaders)
+                GrpcUtil.addHeadersToAllRequests(client, selfAuthHeaders);
               break;
             case ServiceType.KALIX_SERVICE:
-              GrpcUtil.addHeadersToAllRequests(
-                client,
-                otherKalixServiceAuthHeaders,
-              );
+              if (otherKalixServiceAuthHeaders)
+                GrpcUtil.addHeadersToAllRequests(
+                  client,
+                  otherKalixServiceAuthHeaders,
+                );
               break;
           }
         }

--- a/sdk/src/grpc-util.ts
+++ b/sdk/src/grpc-util.ts
@@ -197,7 +197,7 @@ export class GrpcUtil {
       const originalMethod = client[methodName];
       // patch methods that are service calls
       if (originalMethod.requestStream !== undefined) {
-        const patchedMethod = function patched() {
+        const patchedMethod: any = function patched() {
           // service calls has 2-4 parameters, find the metadata parameter if there is one
           const args = Array.prototype.slice.call(arguments);
           const indexOfMeta = args.findIndex((p) => p instanceof grpc.Metadata);
@@ -212,6 +212,10 @@ export class GrpcUtil {
           // call original method with patched metadata
           originalMethod.apply(client, args);
         };
+        // copy fields from original method so that promisify works (sketchy)
+        for (var attr in originalMethod) {
+          patchedMethod[attr] = originalMethod[attr];
+        }
         client[methodName] = patchedMethod;
       }
     });

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -53,6 +53,10 @@ export {
   MetadataEntry,
   MetadataMap,
   MetadataValue,
+  Principal,
+  Principals,
+  PredefinedPrincipal,
+  LocalServicePrincipal,
 } from './metadata';
 export { Cloudevent } from './cloudevent';
 export { JwtClaims } from './jwt-claims';

--- a/sdk/src/index.ts
+++ b/sdk/src/index.ts
@@ -24,6 +24,7 @@ export {
   EntityPassivationStrategy,
   ReplicatedWriteConsistency,
   ServiceBinding,
+  PreStartSettings,
 } from './kalix';
 
 export { Action } from './action';

--- a/sdk/src/kalix.ts
+++ b/sdk/src/kalix.ts
@@ -246,6 +246,8 @@ export interface Component {
 
   /**
    * Internal method for setting up the component.
+   *
+   * @internal
    */
   preStart(settings: PreStartSettings): void;
 }

--- a/sdk/src/kalix.ts
+++ b/sdk/src/kalix.ts
@@ -553,6 +553,7 @@ export class Kalix {
           const result = self.discoveryLogic(call.request);
           callback(null, result);
         } catch (error: any) {
+          console.error('Error handling discovery', error);
           callback(error as Error, null);
         }
       },

--- a/sdk/src/metadata.ts
+++ b/sdk/src/metadata.ts
@@ -437,7 +437,7 @@ export class Metadata {
   /**
    * Get the Principals associated with this request.
    */
-  principals(): Principals {
+  get principals(): Principals {
     const sourceMeta = this.get(PrincipalsSource);
     let source: string | undefined = undefined;
     if (sourceMeta.length > 0) {

--- a/sdk/src/metadata.ts
+++ b/sdk/src/metadata.ts
@@ -437,7 +437,7 @@ export class Metadata {
   /**
    * Get the Principals associated with this request.
    */
-  get principals(): Principals {
+  principals(): Principals {
     const sourceMeta = this.get(PrincipalsSource);
     let source: string | undefined = undefined;
     if (sourceMeta.length > 0) {

--- a/sdk/src/view.ts
+++ b/sdk/src/view.ts
@@ -18,7 +18,12 @@ import * as protobufHelper from './protobuf-helper';
 import * as grpc from '@grpc/grpc-js';
 import * as protoLoader from '@grpc/proto-loader';
 import ViewServices from './view-support';
-import { Component, ComponentOptions, ServiceMap } from './kalix';
+import {
+  Component,
+  ComponentOptions,
+  PreStartSettings,
+  ServiceMap,
+} from './kalix';
 import { Metadata } from './metadata';
 
 const viewServices = new ViewServices();
@@ -125,6 +130,7 @@ export class View<
   readonly serviceName: string;
   readonly service: protobuf.Service;
   readonly options: Required<View.Options>;
+  readonly clients = undefined;
 
   /** @internal */ readonly root: protobuf.Root;
   /** @internal */ readonly grpc: grpc.GrpcObject;
@@ -177,6 +183,8 @@ export class View<
 
     this.grpc = grpc.loadPackageDefinition(packageDefinition);
   }
+
+  preStart(settings: PreStartSettings): void {}
 
   /** @internal */
   componentType(): string {

--- a/sdk/test/metadata.test.ts
+++ b/sdk/test/metadata.test.ts
@@ -15,8 +15,7 @@
  */
 
 import { expect } from 'chai';
-import { Metadata, PredefinedPrincipal } from '../src/metadata';
-import { LocalServicePrincipal } from '../dist';
+import { Metadata, PredefinedPrincipal, LocalServicePrincipal } from '../src/metadata';
 
 describe('Metadata', () => {
   it('should return empty array for missing keys', () => {

--- a/sdk/test/metadata.test.ts
+++ b/sdk/test/metadata.test.ts
@@ -15,7 +15,11 @@
  */
 
 import { expect } from 'chai';
-import { Metadata, PredefinedPrincipal, LocalServicePrincipal } from '../src/metadata';
+import {
+  Metadata,
+  PredefinedPrincipal,
+  LocalServicePrincipal,
+} from '../src/metadata';
 
 describe('Metadata', () => {
   it('should return empty array for missing keys', () => {

--- a/sdk/test/metadata.test.ts
+++ b/sdk/test/metadata.test.ts
@@ -186,28 +186,26 @@ describe('Metadata', () => {
   it('allows inspecting the Self principal', () => {
     const meta = new Metadata();
     meta.set('_kalix-src', 'self');
-    expect(meta.principals().getLocalService()).to.be.undefined;
-    expect(meta.principals().isInternet()).to.be.false;
-    expect(meta.principals().isBackoffice()).to.be.false;
-    expect(meta.principals().isLocalService('servicename')).to.be.false;
-    expect(meta.principals().isAnyLocalService()).to.be.false;
-    expect(meta.principals().isSelf()).to.be.true;
-    expect(meta.principals().get()).to.be.deep.equal([
-      PredefinedPrincipal.Self,
-    ]);
+    expect(meta.principals.getLocalService()).to.be.undefined;
+    expect(meta.principals.isInternet()).to.be.false;
+    expect(meta.principals.isBackoffice()).to.be.false;
+    expect(meta.principals.isLocalService('servicename')).to.be.false;
+    expect(meta.principals.isAnyLocalService()).to.be.false;
+    expect(meta.principals.isSelf()).to.be.true;
+    expect(meta.principals.get()).to.be.deep.equal([PredefinedPrincipal.Self]);
   });
 
   it('allows inspecting other Kalix service principal', () => {
     const meta = new Metadata();
     meta.set('_kalix-src-svc', 'servicename');
-    expect(meta.principals().getLocalService()).to.be.equal('servicename');
-    expect(meta.principals().isInternet()).to.be.false;
-    expect(meta.principals().isBackoffice()).to.be.false;
-    expect(meta.principals().isLocalService('servicename')).to.be.true;
-    expect(meta.principals().isLocalService('otherservicename')).to.be.false;
-    expect(meta.principals().isAnyLocalService()).to.be.true;
-    expect(meta.principals().isSelf()).to.be.false;
-    expect(meta.principals().get()).to.be.deep.equal([
+    expect(meta.principals.getLocalService()).to.be.equal('servicename');
+    expect(meta.principals.isInternet()).to.be.false;
+    expect(meta.principals.isBackoffice()).to.be.false;
+    expect(meta.principals.isLocalService('servicename')).to.be.true;
+    expect(meta.principals.isLocalService('otherservicename')).to.be.false;
+    expect(meta.principals.isAnyLocalService()).to.be.true;
+    expect(meta.principals.isSelf()).to.be.false;
+    expect(meta.principals.get()).to.be.deep.equal([
       new LocalServicePrincipal('servicename'),
     ]);
   });
@@ -215,13 +213,13 @@ describe('Metadata', () => {
   it('allows inspecting Internet principal', () => {
     const meta = new Metadata();
     meta.set('_kalix-src', 'internet');
-    expect(meta.principals().getLocalService()).to.be.undefined;
-    expect(meta.principals().isInternet()).to.be.true;
-    expect(meta.principals().isBackoffice()).to.be.false;
-    expect(meta.principals().isLocalService('servicename')).to.be.false;
-    expect(meta.principals().isAnyLocalService()).to.be.false;
-    expect(meta.principals().isSelf()).to.be.false;
-    expect(meta.principals().get()).to.be.deep.equal([
+    expect(meta.principals.getLocalService()).to.be.undefined;
+    expect(meta.principals.isInternet()).to.be.true;
+    expect(meta.principals.isBackoffice()).to.be.false;
+    expect(meta.principals.isLocalService('servicename')).to.be.false;
+    expect(meta.principals.isAnyLocalService()).to.be.false;
+    expect(meta.principals.isSelf()).to.be.false;
+    expect(meta.principals.get()).to.be.deep.equal([
       PredefinedPrincipal.Internet,
     ]);
   });
@@ -229,13 +227,13 @@ describe('Metadata', () => {
   it('allows inspecting backoffice principal', () => {
     const meta = new Metadata();
     meta.set('_kalix-src', 'backoffice');
-    expect(meta.principals().getLocalService()).to.be.undefined;
-    expect(meta.principals().isInternet()).to.be.false;
-    expect(meta.principals().isBackoffice()).to.be.true;
-    expect(meta.principals().isLocalService('servicename')).to.be.false;
-    expect(meta.principals().isAnyLocalService()).to.be.false;
-    expect(meta.principals().isSelf()).to.be.false;
-    expect(meta.principals().get()).to.be.deep.equal([
+    expect(meta.principals.getLocalService()).to.be.undefined;
+    expect(meta.principals.isInternet()).to.be.false;
+    expect(meta.principals.isBackoffice()).to.be.true;
+    expect(meta.principals.isLocalService('servicename')).to.be.false;
+    expect(meta.principals.isAnyLocalService()).to.be.false;
+    expect(meta.principals.isSelf()).to.be.false;
+    expect(meta.principals.get()).to.be.deep.equal([
       PredefinedPrincipal.Backoffice,
     ]);
   });

--- a/sdk/test/metadata.test.ts
+++ b/sdk/test/metadata.test.ts
@@ -15,7 +15,8 @@
  */
 
 import { expect } from 'chai';
-import { Metadata } from '../src/metadata';
+import { Metadata, PredefinedPrincipal } from '../src/metadata';
+import { LocalServicePrincipal } from '../dist';
 
 describe('Metadata', () => {
   it('should return empty array for missing keys', () => {
@@ -177,5 +178,62 @@ describe('Metadata', () => {
     const meta = new Metadata();
     meta.set('_kalix-jwt-claim-foo', '["foo","bar"]');
     expect(meta.jwtClaims.getStringArray('foo')).to.eql(['foo', 'bar']);
+  });
+
+  it('allows inspecting the Self principal', () => {
+    const meta = new Metadata();
+    meta.set('_kalix-src', 'self');
+    expect(meta.principals().getLocalService()).to.be.undefined;
+    expect(meta.principals().isInternet()).to.be.false;
+    expect(meta.principals().isBackoffice()).to.be.false;
+    expect(meta.principals().isLocalService('servicename')).to.be.false;
+    expect(meta.principals().isAnyLocalService()).to.be.false;
+    expect(meta.principals().isSelf()).to.be.true;
+    expect(meta.principals().get()).to.be.deep.equal([
+      PredefinedPrincipal.Self,
+    ]);
+  });
+
+  it('allows inspecting other Kalix service principal', () => {
+    const meta = new Metadata();
+    meta.set('_kalix-src-svc', 'servicename');
+    expect(meta.principals().getLocalService()).to.be.equal('servicename');
+    expect(meta.principals().isInternet()).to.be.false;
+    expect(meta.principals().isBackoffice()).to.be.false;
+    expect(meta.principals().isLocalService('servicename')).to.be.true;
+    expect(meta.principals().isLocalService('otherservicename')).to.be.false;
+    expect(meta.principals().isAnyLocalService()).to.be.true;
+    expect(meta.principals().isSelf()).to.be.false;
+    expect(meta.principals().get()).to.be.deep.equal([
+      new LocalServicePrincipal('servicename'),
+    ]);
+  });
+
+  it('allows inspecting Internet principal', () => {
+    const meta = new Metadata();
+    meta.set('_kalix-src', 'internet');
+    expect(meta.principals().getLocalService()).to.be.undefined;
+    expect(meta.principals().isInternet()).to.be.true;
+    expect(meta.principals().isBackoffice()).to.be.false;
+    expect(meta.principals().isLocalService('servicename')).to.be.false;
+    expect(meta.principals().isAnyLocalService()).to.be.false;
+    expect(meta.principals().isSelf()).to.be.false;
+    expect(meta.principals().get()).to.be.deep.equal([
+      PredefinedPrincipal.Internet,
+    ]);
+  });
+
+  it('allows inspecting backoffice principal', () => {
+    const meta = new Metadata();
+    meta.set('_kalix-src', 'backoffice');
+    expect(meta.principals().getLocalService()).to.be.undefined;
+    expect(meta.principals().isInternet()).to.be.false;
+    expect(meta.principals().isBackoffice()).to.be.true;
+    expect(meta.principals().isLocalService('servicename')).to.be.false;
+    expect(meta.principals().isAnyLocalService()).to.be.false;
+    expect(meta.principals().isSelf()).to.be.false;
+    expect(meta.principals().get()).to.be.deep.equal([
+      PredefinedPrincipal.Backoffice,
+    ]);
   });
 });

--- a/sdk/test/metadata.test.ts
+++ b/sdk/test/metadata.test.ts
@@ -186,26 +186,28 @@ describe('Metadata', () => {
   it('allows inspecting the Self principal', () => {
     const meta = new Metadata();
     meta.set('_kalix-src', 'self');
-    expect(meta.principals.getLocalService()).to.be.undefined;
-    expect(meta.principals.isInternet()).to.be.false;
-    expect(meta.principals.isBackoffice()).to.be.false;
-    expect(meta.principals.isLocalService('servicename')).to.be.false;
-    expect(meta.principals.isAnyLocalService()).to.be.false;
-    expect(meta.principals.isSelf()).to.be.true;
-    expect(meta.principals.get()).to.be.deep.equal([PredefinedPrincipal.Self]);
+    expect(meta.principals().getLocalService()).to.be.undefined;
+    expect(meta.principals().isInternet()).to.be.false;
+    expect(meta.principals().isBackoffice()).to.be.false;
+    expect(meta.principals().isLocalService('servicename')).to.be.false;
+    expect(meta.principals().isAnyLocalService()).to.be.false;
+    expect(meta.principals().isSelf()).to.be.true;
+    expect(meta.principals().get()).to.be.deep.equal([
+      PredefinedPrincipal.Self,
+    ]);
   });
 
   it('allows inspecting other Kalix service principal', () => {
     const meta = new Metadata();
     meta.set('_kalix-src-svc', 'servicename');
-    expect(meta.principals.getLocalService()).to.be.equal('servicename');
-    expect(meta.principals.isInternet()).to.be.false;
-    expect(meta.principals.isBackoffice()).to.be.false;
-    expect(meta.principals.isLocalService('servicename')).to.be.true;
-    expect(meta.principals.isLocalService('otherservicename')).to.be.false;
-    expect(meta.principals.isAnyLocalService()).to.be.true;
-    expect(meta.principals.isSelf()).to.be.false;
-    expect(meta.principals.get()).to.be.deep.equal([
+    expect(meta.principals().getLocalService()).to.be.equal('servicename');
+    expect(meta.principals().isInternet()).to.be.false;
+    expect(meta.principals().isBackoffice()).to.be.false;
+    expect(meta.principals().isLocalService('servicename')).to.be.true;
+    expect(meta.principals().isLocalService('otherservicename')).to.be.false;
+    expect(meta.principals().isAnyLocalService()).to.be.true;
+    expect(meta.principals().isSelf()).to.be.false;
+    expect(meta.principals().get()).to.be.deep.equal([
       new LocalServicePrincipal('servicename'),
     ]);
   });
@@ -213,13 +215,13 @@ describe('Metadata', () => {
   it('allows inspecting Internet principal', () => {
     const meta = new Metadata();
     meta.set('_kalix-src', 'internet');
-    expect(meta.principals.getLocalService()).to.be.undefined;
-    expect(meta.principals.isInternet()).to.be.true;
-    expect(meta.principals.isBackoffice()).to.be.false;
-    expect(meta.principals.isLocalService('servicename')).to.be.false;
-    expect(meta.principals.isAnyLocalService()).to.be.false;
-    expect(meta.principals.isSelf()).to.be.false;
-    expect(meta.principals.get()).to.be.deep.equal([
+    expect(meta.principals().getLocalService()).to.be.undefined;
+    expect(meta.principals().isInternet()).to.be.true;
+    expect(meta.principals().isBackoffice()).to.be.false;
+    expect(meta.principals().isLocalService('servicename')).to.be.false;
+    expect(meta.principals().isAnyLocalService()).to.be.false;
+    expect(meta.principals().isSelf()).to.be.false;
+    expect(meta.principals().get()).to.be.deep.equal([
       PredefinedPrincipal.Internet,
     ]);
   });
@@ -227,13 +229,13 @@ describe('Metadata', () => {
   it('allows inspecting backoffice principal', () => {
     const meta = new Metadata();
     meta.set('_kalix-src', 'backoffice');
-    expect(meta.principals.getLocalService()).to.be.undefined;
-    expect(meta.principals.isInternet()).to.be.false;
-    expect(meta.principals.isBackoffice()).to.be.true;
-    expect(meta.principals.isLocalService('servicename')).to.be.false;
-    expect(meta.principals.isAnyLocalService()).to.be.false;
-    expect(meta.principals.isSelf()).to.be.false;
-    expect(meta.principals.get()).to.be.deep.equal([
+    expect(meta.principals().getLocalService()).to.be.undefined;
+    expect(meta.principals().isInternet()).to.be.false;
+    expect(meta.principals().isBackoffice()).to.be.true;
+    expect(meta.principals().isLocalService('servicename')).to.be.false;
+    expect(meta.principals().isAnyLocalService()).to.be.false;
+    expect(meta.principals().isSelf()).to.be.false;
+    expect(meta.principals().get()).to.be.deep.equal([
       PredefinedPrincipal.Backoffice,
     ]);
   });

--- a/sdk/types/protocol/discovery.ts
+++ b/sdk/types/protocol/discovery.ts
@@ -32,3 +32,4 @@ export { ReplicatedEntitySettings } from '../generated/proto/kalix/protocol/Repl
 
 export { UserFunctionError__Output as UserFunctionError } from '../generated/proto/kalix/protocol/UserFunctionError';
 export { _kalix_protocol_UserFunctionError_SourceLocation__Output as SourceLocation } from '../generated/proto/kalix/protocol/UserFunctionError';
+export { IdentificationInfo__Output as IdentificationInfo } from '../generated/proto/kalix/protocol/IdentificationInfo';

--- a/testkit/example/proto/example.proto
+++ b/testkit/example/proto/example.proto
@@ -49,6 +49,20 @@ service ExampleActionService {
   rpc Fail(In) returns (Out);
 }
 
+
+service ExampleActionWithACLService {
+  option (kalix.service) = {
+    type : SERVICE_TYPE_ACTION
+  };
+
+  rpc Public(In) returns (Out) {
+    option (kalix.method).acl.allow = { principal: ALL };
+  };
+  rpc OnlyFromOtherService(In) returns (Out) {
+    option (kalix.method).acl.allow = { service: "other" };
+  };
+}
+
 option (kalix.file).value_entity = {
   name: "ExampleValueEntity"
   entity_type: "example-value-entity"

--- a/testkit/example/proto/example.proto
+++ b/testkit/example/proto/example.proto
@@ -61,6 +61,12 @@ service ExampleActionWithACLService {
   rpc OnlyFromOtherService(In) returns (Out) {
     option (kalix.method).acl.allow = { service: "other" };
   };
+  rpc OnlyFromSelf(In) returns (Out) {
+    option (kalix.method).acl.allow = { service: "self" };
+  }
+  rpc DelegateToSelf(In) returns (Out) {
+    option (kalix.method).acl.allow = { principal: ALL };
+  }
 }
 
 option (kalix.file).value_entity = {

--- a/testkit/example/src/action-with-acl.ts
+++ b/testkit/example/src/action-with-acl.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 Lightbend Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import {
+  Action,
+  LocalServicePrincipal,
+  PredefinedPrincipal,
+  Principal,
+} from '@kalix-io/kalix-javascript-sdk';
+import { ExampleActionWithAclService } from '../types/action';
+
+const action: ExampleActionWithAclService = new Action(
+  'example.proto',
+  'com.example.ExampleActionWithACLService',
+  {
+    includeDirs: ['example/proto'],
+  },
+);
+
+function principalToString(principal: Principal) {
+  if (principal instanceof LocalServicePrincipal) {
+    return principal.name;
+  } else {
+    switch (principal) {
+      case PredefinedPrincipal.Self:
+        return 'self';
+      case PredefinedPrincipal.Backoffice:
+        return 'backoffice';
+      case PredefinedPrincipal.Internet:
+        return 'internet';
+    }
+  }
+}
+
+action.commandHandlers = {
+  Public: (input, context) => {
+    return {
+      field:
+        'Received: ' +
+        input.field +
+        ', principals: ' +
+        context.metadata.principals.get().map(principalToString),
+    };
+  },
+  OnlyFromOtherService: (input, context) => {
+    return {
+      field:
+        'Received: ' +
+        input.field +
+        ', principals: ' +
+        context.metadata.principals.get().map(principalToString),
+    };
+  },
+};
+
+export default action;

--- a/testkit/example/src/action-with-acl.ts
+++ b/testkit/example/src/action-with-acl.ts
@@ -16,6 +16,8 @@
 
 import {
   Action,
+  GrpcClientCreator,
+  GrpcClientLookup,
   LocalServicePrincipal,
   PredefinedPrincipal,
   Principal,
@@ -63,6 +65,23 @@ action.commandHandlers = {
         ', principals: ' +
         context.metadata.principals.get().map(principalToString),
     };
+  },
+  OnlyFromSelf: (input, context) => {
+    return {
+      field:
+        'OnlyFromSelf Received: ' +
+        input.field +
+        ', principals: ' +
+        context.metadata.principals.get().map(principalToString),
+    };
+  },
+  DelegateToSelf: (input) => {
+    // FIXME TS lookup doesn't seem to quite work for nested packages, needs this mess:
+    const clientFactory = (
+      (action.clients!.com as GrpcClientLookup).example as GrpcClientLookup
+    ).ExampleActionWithACLService as GrpcClientCreator;
+    const client = clientFactory.createClient();
+    return client.OnlyFromSelf(input);
   },
 };
 

--- a/testkit/example/src/action-with-acl.ts
+++ b/testkit/example/src/action-with-acl.ts
@@ -21,6 +21,7 @@ import {
   LocalServicePrincipal,
   PredefinedPrincipal,
   Principal,
+  replies,
 } from '@kalix-io/kalix-javascript-sdk';
 import { ExampleActionWithAclService } from '../types/action';
 
@@ -75,13 +76,18 @@ action.commandHandlers = {
         context.metadata.principals.get().map(principalToString),
     };
   },
-  DelegateToSelf: (input) => {
+  DelegateToSelf: async (input) => {
     // FIXME TS lookup doesn't seem to quite work for nested packages, needs this mess:
     const clientFactory = (
       (action.clients!.com as GrpcClientLookup).example as GrpcClientLookup
     ).ExampleActionWithACLService as GrpcClientCreator;
     const client = clientFactory.createClient();
-    return client.OnlyFromSelf(input);
+    try {
+      return await client.OnlyFromSelf(input);
+    } catch (e) {
+      console.error('Calling self failed', e);
+      return replies.failure('Cross component call failed');
+    }
   },
 };
 

--- a/testkit/example/src/action-with-acl.ts
+++ b/testkit/example/src/action-with-acl.ts
@@ -55,7 +55,7 @@ action.commandHandlers = {
         'Received: ' +
         input.field +
         ', principals: ' +
-        context.metadata.principals.get().map(principalToString),
+        context.metadata.principals().get().map(principalToString),
     };
   },
   OnlyFromOtherService: (input, context) => {
@@ -64,7 +64,7 @@ action.commandHandlers = {
         'Received: ' +
         input.field +
         ', principals: ' +
-        context.metadata.principals.get().map(principalToString),
+        context.metadata.principals().get().map(principalToString),
     };
   },
   OnlyFromSelf: (input, context) => {
@@ -73,7 +73,7 @@ action.commandHandlers = {
         'OnlyFromSelf Received: ' +
         input.field +
         ', principals: ' +
-        context.metadata.principals.get().map(principalToString),
+        context.metadata.principals().get().map(principalToString),
     };
   },
   DelegateToSelf: async (input) => {

--- a/testkit/example/types/action.d.ts
+++ b/testkit/example/types/action.d.ts
@@ -42,5 +42,21 @@ export declare namespace ExampleActionService {
   };
 }
 
+export declare namespace ExampleActionWithAclService {
+  type CommandHandlers = {
+    Public: (
+      command: api.In,
+      ctx: Action.UnaryCommandContext<api.IOut>,
+    ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
+    OnlyFromOtherService: (
+      command: api.In,
+      ctx: Action.UnaryCommandContext<api.IOut>,
+    ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
+  };
+}
+
 export declare type ExampleActionService =
   Action<ExampleActionService.CommandHandlers>;
+
+export declare type ExampleActionWithAclService =
+  Action<ExampleActionWithAclService.CommandHandlers>;

--- a/testkit/example/types/action.d.ts
+++ b/testkit/example/types/action.d.ts
@@ -52,6 +52,14 @@ export declare namespace ExampleActionWithAclService {
       command: api.In,
       ctx: Action.UnaryCommandContext<api.IOut>,
     ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
+    OnlyFromSelf: (
+      command: api.In,
+      ctx: Action.UnaryCommandContext<api.IOut>,
+    ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
+    DelegateToSelf: (
+      command: api.In,
+      ctx: Action.UnaryCommandContext<api.IOut>,
+    ) => CommandReply<api.IOut> | Promise<CommandReply<api.IOut>>;
   };
 }
 

--- a/testkit/integration-test/integration-testkit.test.ts
+++ b/testkit/integration-test/integration-testkit.test.ts
@@ -86,7 +86,8 @@ describe('The Kalix IntegrationTestkit', function () {
       );
   });
 
-  it('should handle actions with acl', (done) => {
+  it('should handle self-delegating actions (with acl)', (done) => {
+    // Note: not really a test of the testkit but that the SDK sets inter-component calls up right
     testkit.clients.ExampleActionWithACLService.DelegateToSelf(
       { field: 'hello' },
       (err: any, msg: Out) => {

--- a/testkit/integration-test/integration-testkit.test.ts
+++ b/testkit/integration-test/integration-testkit.test.ts
@@ -80,11 +80,26 @@ describe('The Kalix IntegrationTestkit', function () {
             done(err);
           } else {
             msg.field?.should.equal('Received: hello, principals: other');
-            console.log(msg);
             done();
           }
         },
       );
+  });
+
+  it('should handle actions with acl', (done) => {
+    testkit.clients.ExampleActionWithACLService.DelegateToSelf(
+      { field: 'hello' },
+      (err: any, msg: Out) => {
+        if (err) {
+          done(err);
+        } else {
+          msg.field?.should.equal(
+            'OnlyFromSelf Received: hello, principals: self',
+          );
+          done();
+        }
+      },
+    );
   });
 
   it('should handle value entities sync handlers', (done) => {

--- a/testkit/src/integration-testkit.ts
+++ b/testkit/src/integration-testkit.ts
@@ -54,10 +54,6 @@ export namespace IntegrationTestkit {
  */
 export interface IntegrationTestKitOptions extends KalixOptions {
   /**
-   * The name of this service when deployed
-   */
-  nameOfService?: String;
-  /**
    * Whether ACL checking is enabled.
    */
   aclCheckingEnabled?: boolean;

--- a/testkit/src/integration-testkit.ts
+++ b/testkit/src/integration-testkit.ts
@@ -20,8 +20,9 @@ import {
   GrpcUtil,
   Kalix,
   KalixOptions,
-  Principal,
+  LocalServicePrincipal,
   PredefinedPrincipal,
+  Principal,
   settings,
 } from '@kalix-io/kalix-javascript-sdk';
 import { GenericContainer, TestContainers, Wait } from 'testcontainers';
@@ -115,16 +116,16 @@ export class IntegrationTestkit {
    * @param principal The principal to authenticate calls to the service as.
    */
   clientsForPrincipal(principal: Principal): { [serviceName: string]: any } {
-    const metadata = new grpc.Metadata();
-    if (principal == PredefinedPrincipal.Internet) {
-      metadata.add('_kalix-src', 'internet');
-    } else if (principal == PredefinedPrincipal.Backoffice) {
-      metadata.add('_kalix-src', 'backoffice');
-    } else if (principal == PredefinedPrincipal.Self) {
-      metadata.add('_kalix-src', 'self');
+    var serviceName: string;
+    if (principal == PredefinedPrincipal.Self) {
+      serviceName = this.options.serviceName!;
+    } else if (principal instanceof LocalServicePrincipal) {
+      serviceName = principal.name.toString();
     } else {
-      metadata.add('_kalix-src-svc', principal.name!.toString());
+      throw new Error("Only 'Self' and 'LocalServicePrincipal' is supported");
     }
+    const metadata = new grpc.Metadata();
+    metadata.add('impersonate-kalix-service', serviceName);
     return this.createClients(this.proxyPort!, metadata);
   }
 


### PR DESCRIPTION
References #354 

 * pass along proxy hostname and auth headers to grpc clients and inject 
    - **breaking API change**: clients can no longer be created before `preStart` has been called triggered by discovery
 * APIs for inspecting principal
 * default acl for an entire service (docs only)
 * testkit support for fake principal
 * test coverage
 * figure out why self-calls does not work getting `14 UNAVAILABLE: No connection established` - test container needs to inform SDK about proxy port
