### PR TITLE
bump: updates for apple silicon

### DIFF
--- a/codegen/build.sbt
+++ b/codegen/build.sbt
@@ -49,6 +49,7 @@ lazy val `kalix-codegen-js-cli` =
       buildInfoKeys := Seq[BuildInfoKey](version),
       buildInfoPackage := "io.kalix.codegen.js",
       name in NativeImage := "kalix-codegen-js",
+      nativeImageVersion := "22.1.0",
       /**
        * Due to limitations of the Windows command prompt/PowerShell, with a the native-image command fails with a long
        * classpath By using sbt-assembly, we first build a fat JAR which is then able to be used in place of the full

--- a/npm-js/kalix-scripts/bin/download-codegen.js
+++ b/npm-js/kalix-scripts/bin/download-codegen.js
@@ -16,7 +16,13 @@ const releases = {
   win32_x86_64: 'kalix-codegen-js-x86_64-pc-windows-gnu',
 };
 
-const arch = process.arch === 'x64' ? 'x86_64' : 'x86_32';
+const arch =
+  process.platform === 'darwin' && process.arch === 'arm64'
+    ? 'x86_64' // use rosetta for darwin arm64 for now
+    : process.arch === 'x64'
+    ? 'x86_64'
+    : 'x86_32';
+
 const release = `${process.platform}_${arch}`;
 
 // Windows requires executable files to have some file extension, but we need a consistent name cross-platform

--- a/sdk/bin/download-protoc.js
+++ b/sdk/bin/download-protoc.js
@@ -9,7 +9,7 @@ const rimraf = require('rimraf');
 
 const downloadUrlPrefix =
   'https://github.com/protocolbuffers/protobuf/releases/download/v';
-const protocVersion = '3.15.6';
+const protocVersion = '3.20.1';
 function makeDownloadFile(platformArch) {
   return 'protoc-' + protocVersion + '-' + platformArch + '.zip';
 }
@@ -42,8 +42,7 @@ function determineDownloadFile() {
         case 'x64':
           return makeDownloadFile('osx-x86_64');
         case 'arm64':
-          // use rosetta for now
-          return makeDownloadFile('osx-x86_64');
+          return makeDownloadFile('osx-aarch_64');
       }
       break;
   }


### PR DESCRIPTION
Refs #99.

I don't have an M1 mac to try this out on, but trying out some updates.

Bump protoc to a version which has an `osx-aarch_64` download. Not strictly needed if running the x86 version with rosetta works anyway.

Bump `nativeImageVersion` for building locally. Should automatically download an M1-compatible graalvm.

CircleCI doesn't support M1 runners yet, so we can't automatically publish the codegen binaries. Use the x86 download with rosetta instead for now.

@johanandren, can you check whether this works? We can also make a release if it's easier to test in a sample properly.