### PR TITLE
build: fix testkit published version

### DIFF
--- a/testkit/package.json
+++ b/testkit/package.json
@@ -58,7 +58,7 @@
     "test": "mocha",
     "preintegration-test": "npm run example:build",
     "integration-test": "mocha integration-test/**/*.test.ts",
-    "prepublishOnly": "npm version --no-git-tag-version $(bin/version.sh)"
+    "prepublishOnly": "npm version --no-git-tag-version $(../sdk/bin/version.sh)"
   },
   "publishConfig": {
     "@kalix-io:registry": "https://registry.npmjs.org"


### PR DESCRIPTION
Testkit didn't have its version updated on publish (and published 0.0.0 instead). Can publish a `1.0.0-M9` manually.