### PR TITLE
doc: standardize Quickstart code conventions

### DIFF
--- a/samples/js/js-eventsourced-shopping-cart/src/index.js
+++ b/samples/js/js-eventsourced-shopping-cart/src/index.js
@@ -14,15 +14,11 @@
  * limitations under the License.
  */
 // tag::imports[]
-import { Kalix } from "@kalix-io/kalix-javascript-sdk";
-import generatedComponents from "../lib/generated/index.js";
+const Kalix = require("@kalix-io/kalix-javascript-sdk").Kalix
 // end::imports[]
 // tag::server[]
+console.log("Starting Event Sourced Entity")
 const server = new Kalix();
-
-generatedComponents.forEach((component) => {
-  server.addComponent(component);
-});
-
+server.addComponent(require("./shoppingcart.js"))
 server.start();
 // end::server[]

--- a/samples/js/js-eventsourced-shopping-cart/src/shoppingcart.js
+++ b/samples/js/js-eventsourced-shopping-cart/src/shoppingcart.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 // tag::imports[]
-import { EventSourcedEntity } from "@kalix-io/kalix-javascript-sdk";
+const EventSourcedEntity = require("@kalix-io/kalix-javascript-sdk").EventSourcedEntity;
 // end::imports[]
 /**
  * Type definitions.
@@ -37,10 +37,7 @@ const entity = new EventSourcedEntity(
     "shoppingcart_api.proto"
   ],
   "com.example.shoppingcart.ShoppingCartService",
-  "eventsourced-shopping-cart",
-  {
-    includeDirs: ["./proto"]
-  }
+  "eventsourced-shopping-cart"
 );
 // end::esentity[]
 /*
@@ -190,5 +187,5 @@ function itemRemoved(removed, cart) {
 // end::itemremoved[]
 
 // tag::export[]
-export default entity;
+module.exports = entity;
 // end::export[]


### PR DESCRIPTION
Migrate Event Sourced Entity Quickstart module format from ES to
CommonsJS. This standardizes both the Value Entity Quickstart and
Event Sourced Entity Quickstart on the same module format.

Refs: https://github.com/lightbend/kalix/issues/6977