### PR TITLE
fix: support docker build on arm64 in kalix-scripts

### DIFF
--- a/npm-js/kalix-scripts/bin/kalix-scripts.js
+++ b/npm-js/kalix-scripts/bin/kalix-scripts.js
@@ -15,9 +15,14 @@ const requiredConfig = [
 
 const kalixScriptDir = path.resolve(__dirname, '..');
 
+const dockerBuildArgs =
+  process.arch === 'arm64'
+    ? ['buildx', 'build', '--platform=linux/amd64']
+    : ['build'];
+
 const dockerBuild = (dockerTag) =>
   runOrFail('Building docker image', 'docker', [
-    'build',
+    ...dockerBuildArgs,
     '--tag',
     dockerTag,
     '.',


### PR DESCRIPTION
Refs #99.

Still to be tested on an M1... may be easier to test fully once released, but can be checked locally.