### PR TITLE
docs: avoid nested tabs, nest note instead

### DIFF
--- a/docs/src/modules/javascript/pages/kickstart.adoc
+++ b/docs/src/modules/javascript/pages/kickstart.adoc
@@ -34,11 +34,6 @@ The code generation tools create a new development project named `my-entity`, th
 . To create the initial codebase, from a command window enter the following:
 +
 [.tabset]
-====
-
-JavaScript::
-+
-[.tabset]
 npm:::
 +
 --
@@ -46,6 +41,14 @@ npm:::
 ----
 npx @kalix-io/create-kalix-entity@latest my-entity
 ----
+[NOTE]
+====
+To generate TypeScript sources add the `--typescript` option:
+[source, command window, subs="attributes"]
+----
+npx @kalix-io/create-kalix-entity@latest my-entity --typescript
+----
+====
 --
 yarn:::
 +
@@ -54,31 +57,15 @@ yarn:::
 ----
 yarn create @kalix-io/kalix-entity@latest my-entity
 ----
---
-
-TypeScript::
-+
-[.tabset]
-npm:::
-+
---
-[source, command window, subs="attributes"]
-----
-npx @kalix-io/create-kalix-entity@latest my-entity --typescript
-----
---
-yarn:::
-+
---
+[NOTE]
+====
+To generate TypeScript sources add the `--typescript` option:
 [source, command window, subs="attributes"]
 ----
 yarn create @kalix-io/kalix-entity@latest my-entity --typescript
 ----
---
-
 ====
-+
-NOTE: To generate TypeScript sources add the `--typescript` option.
+--
 
 . Change directories to the newly created folder:
 +


### PR DESCRIPTION
Follow-up to #363. Did start updating the kalix docs theme to allow nested tabs, but it's a bit awkward. Change this one use of nested tabs to instead just have a nested note for the TypeScript variant.