### PR TITLE
feat: generate type lookups for events

### DIFF
--- a/codegen/js-gen/src/main/scala/io/kalix/codegen/js/EntityServiceSourceGenerator.scala
+++ b/codegen/js-gen/src/main/scala/io/kalix/codegen/js/EntityServiceSourceGenerator.scala
@@ -147,6 +147,16 @@ object EntityServiceSourceGenerator {
       line <>
       "const" <+> entity.state.fqn.name <+> equal <+> "entity.lookupType" <> parens(
         dquotes(entity.state.fqn.fullName)) <> semi <> line <>
+      (entity match {
+        case ModelBuilder.EventSourcedEntity(_, _, _, events) =>
+          ssep(
+            events.toSeq.map { event =>
+              "const" <+> event.fqn.name <+> equal <+> "entity.lookupType" <> parens(
+                dquotes(event.fqn.fullName)) <> semi
+            },
+            line) <> (if (events.isEmpty) emptyDoc else line)
+        case _: ModelBuilder.ValueEntity => emptyDoc
+      }) <>
       line <>
       "entity.setInitial" <> parens(
         "entityId => " <> entity.state.fqn.name <> ".create" <> parens("{}")) <> semi <> line <>
@@ -171,7 +181,7 @@ object EntityServiceSourceGenerator {
                   event.fqn.name <> parens("event, state") <+> braces(nest(line <>
                   "return state") <> semi <> line)
                 },
-                comma)) <> line)) <> line))) <> semi
+                comma <> line)) <> line)) <> line))) <> semi
         case _: ModelBuilder.ValueEntity =>
           "entity.setCommandHandlers" <> parens(
             braces(nest(line <>

--- a/codegen/js-gen/src/test/scala/io/kalix/codegen/js/EntityServiceSourceGeneratorSuite.scala
+++ b/codegen/js-gen/src/test/scala/io/kalix/codegen/js/EntityServiceSourceGeneratorSuite.scala
@@ -62,6 +62,8 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |);
         |
         |const MyState = entity.lookupType("com.example.service.persistence.MyState");
+        |const EventOne = entity.lookupType("com.example.service.persistence.EventOne");
+        |const EventTwo = entity.lookupType("com.example.service.persistence.EventTwo");
         |
         |entity.setInitial(entityId => MyState.create({}));
         |
@@ -76,7 +78,10 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |  },
         |  
         |  eventHandlers: {
-        |    SetEvent(event, state) {
+        |    EventOne(event, state) {
+        |      return state;
+        |    },
+        |    EventTwo(event, state) {
         |      return state;
         |    }
         |  }
@@ -128,6 +133,8 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |);
         |
         |const MyState = entity.lookupType("com.example.service.persistence.MyState");
+        |const EventOne = entity.lookupType("com.example.service.persistence.EventOne");
+        |const EventTwo = entity.lookupType("com.example.service.persistence.EventTwo");
         |
         |entity.setInitial(entityId => MyState.create({}));
         |
@@ -142,7 +149,10 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |  },
         |  
         |  eventHandlers: {
-        |    SetEvent(event, state) {
+        |    EventOne(event, state) {
+        |      return state;
+        |    },
+        |    EventTwo(event, state) {
         |      return state;
         |    }
         |  }
@@ -307,18 +317,27 @@ class EntityServiceSourceGeneratorSuite extends munit.FunSuite {
         |  type MyState = proto.com.example.service.persistence.IMyState &
         |    protobuf.Message<proto.com.example.service.persistence.IMyState>;
         |  
-        |  type SetEvent = proto.com.example.service.persistence.ISetEvent &
-        |    protobuf.Message<proto.com.example.service.persistence.ISetEvent>;
+        |  type EventOne = proto.com.example.service.persistence.IEventOne &
+        |    protobuf.Message<proto.com.example.service.persistence.IEventOne>;
+        |  
+        |  type EventTwo = proto.com.example.service.persistence.IEventTwo &
+        |    protobuf.Message<proto.com.example.service.persistence.IEventTwo>;
         |}
         |
         |export declare namespace MyService {
         |  type State = domain.MyState;
         |  
-        |  type Events = domain.SetEvent;
+        |  type Events =
+        |    | domain.EventOne
+        |    | domain.EventTwo;
         |  
         |  type EventHandlers = {
-        |    SetEvent: (
-        |      event: domain.SetEvent,
+        |    EventOne: (
+        |      event: domain.EventOne,
+        |      state: State
+        |    ) => State;
+        |    EventTwo: (
+        |      event: domain.EventTwo,
         |      state: State
         |    ) => State;
         |  };

--- a/codegen/js-gen/src/test/scala/io/kalix/codegen/js/TestData.scala
+++ b/codegen/js-gen/src/test/scala/io/kalix/codegen/js/TestData.scala
@@ -119,7 +119,9 @@ object TestData {
       FullyQualifiedName(s"MyEntity$suffix", domainProto(suffix)),
       entityType = s"my-eventsourcedentity$suffix-persistence",
       ModelBuilder.State(FullyQualifiedName("MyState", domainProto(suffix))),
-      List(ModelBuilder.Event(FullyQualifiedName("SetEvent", domainProto(suffix)))))
+      List(
+        ModelBuilder.Event(FullyQualifiedName("EventOne", domainProto(suffix))),
+        ModelBuilder.Event(FullyQualifiedName("EventTwo", domainProto(suffix)))))
 
   def valueEntity(suffix: String = ""): ModelBuilder.ValueEntity =
     ModelBuilder.ValueEntity(


### PR DESCRIPTION
For event sourced entity codegen, also generate the type lookups for events. These reflective types have to be used for any persisted messages (as only the reflective protobuf has the message name for the Any type url).

Added as an improvement for quickstart docs: https://github.com/lightbend/kalix-docs/pull/1402