### PR TITLE
fix: enable codegen with new annotation

### DIFF
--- a/codegen/core/src/main/scala/io/kalix/codegen/DescriptorSet.scala
+++ b/codegen/core/src/main/scala/io/kalix/codegen/DescriptorSet.scala
@@ -42,6 +42,7 @@ object DescriptorSet {
     Using[FileInputStream, Either[CannotOpen, Iterable[Either[ReadFailure, Descriptors.FileDescriptor]]]](
       new FileInputStream(file)) { fis =>
       val registry = ExtensionRegistry.newInstance()
+      registry.add(kalix.Annotations.codegen)
       registry.add(kalix.Annotations.service)
       registry.add(kalix.Annotations.file)
       registry.add(kalix.Annotations.method)

--- a/codegen/js-gen-cli/src/main/scala/io/kalix/codegen/js/Cli.scala
+++ b/codegen/js-gen-cli/src/main/scala/io/kalix/codegen/js/Cli.scala
@@ -81,7 +81,7 @@ object Cli {
         val protobufDescriptor =
           config.descriptorSetOutputDirectory.resolve(config.descriptorSetFileName).toFile
         if (protobufDescriptor.exists) {
-          println("Inspecting proto file descriptor for entity generation...")
+          println("Inspecting proto file descriptor for Kalix code generation...")
           val _ = DescriptorSet.fileDescriptors(protobufDescriptor) match {
             case Right(fileDescriptors) =>
               val model =

--- a/codegen/js-gen/src/main/scala/io/kalix/codegen/js/SourceGenerator.scala
+++ b/codegen/js-gen/src/main/scala/io/kalix/codegen/js/SourceGenerator.scala
@@ -163,7 +163,7 @@ object SourceGenerator extends PrettyPrinter {
       "import" <+> generatedComponentArray <+> "from" <+> dquotes(generatedComponentIndex) <> semi
       <> line <> line <>
       "const" <+> "server" <+> equal <+> "new" <+> "Kalix" <> parens(emptyDoc) <> semi <> line <> line <>
-      "// This generatedComponentArray array contains all generated Actions, Views or Entities," <> line <>
+      "// This generatedComponents array contains all generated Actions, Views or Entities," <> line <>
       "// and is kept up-to-date with any changes in your protobuf definitions." <> line <>
       "// If you prefer, you may remove this line and manually register these components." <> line <>
       generatedComponentArray <> dot <> "forEach" <> parens(

--- a/codegen/js-gen/src/test/scala/io/kalix/codegen/js/SourceGeneratorSuite.scala
+++ b/codegen/js-gen/src/test/scala/io/kalix/codegen/js/SourceGeneratorSuite.scala
@@ -234,7 +234,7 @@ class SourceGeneratorSuite extends munit.FunSuite {
         |
         |const server = new Kalix();
         |
-        |// This generatedComponentArray array contains all generated Actions, Views or Entities,
+        |// This generatedComponents array contains all generated Actions, Views or Entities,
         |// and is kept up-to-date with any changes in your protobuf definitions.
         |// If you prefer, you may remove this line and manually register these components.
         |generatedComponents.forEach((component) => {
@@ -262,7 +262,7 @@ class SourceGeneratorSuite extends munit.FunSuite {
         |
         |const server = new Kalix();
         |
-        |// This generatedComponentArray array contains all generated Actions, Views or Entities,
+        |// This generatedComponents array contains all generated Actions, Views or Entities,
         |// and is kept up-to-date with any changes in your protobuf definitions.
         |// If you prefer, you may remove this line and manually register these components.
         |generatedComponents.forEach((component) => {


### PR DESCRIPTION
Refs #235. Allow the new codegen annotation to be used (just missing extension registration). There are no tests for this yet, but currently trying it out in updated quickstarts.