### PR TITLE
bump: update node docker image to 14.19

### DIFF
--- a/npm-js/create-kalix-entity/template/base-js/Dockerfile
+++ b/npm-js/create-kalix-entity/template/base-js/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/npm-js/create-kalix-entity/template/base-ts/Dockerfile
+++ b/npm-js/create-kalix-entity/template/base-ts/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-doc-snippets/Dockerfile
+++ b/samples/js/js-doc-snippets/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-eventsourced-shopping-cart/Dockerfile
+++ b/samples/js/js-eventsourced-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-replicated-entity-shopping-cart/Dockerfile
+++ b/samples/js/js-replicated-entity-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-valueentity-shopping-cart/Dockerfile
+++ b/samples/js/js-valueentity-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/valueentity-counter/Dockerfile
+++ b/samples/js/valueentity-counter/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-eventsourced-shopping-cart/Dockerfile
+++ b/samples/ts/ts-eventsourced-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-replicated-entity-shopping-cart/Dockerfile
+++ b/samples/ts/ts-replicated-entity-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-valueentity-counter/Dockerfile
+++ b/samples/ts/ts-valueentity-counter/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-valueentity-shopping-cart/Dockerfile
+++ b/samples/ts/ts-valueentity-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.17.0-buster-slim AS builder
+FROM node:14.19-buster-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.17.0-buster-slim
+FROM node:14.19-buster-slim
 
 # Set the working directory
 WORKDIR /home/node


### PR DESCRIPTION
Not sure if there was a reason to use an exact version, other than just avoiding downloading new images when published. Latest for 14 is `14.19.3`. Could also just use the `node:14-buster-slim` image. Updated to the `14.19` tag as a compromise.