### PR TITLE
chore: remove unnecessary dependencies from templates

### DIFF
--- a/npm-js/create-kalix-entity/template/base-js/package.json
+++ b/npm-js/create-kalix-entity/template/base-js/package.json
@@ -13,9 +13,7 @@
     "@kalix-io/kalix-scripts": "{{scriptsVersion}}",
     "@kalix-io/testkit": "{{testkitVersion}}",
     "chai": "^4.3.6",
-    "jsdoc": "^3.6.10",
-    "mocha": "^10.0.0",
-    "uglify-js": "^3.16.1"
+    "mocha": "^10.0.0"
   },
   "config": {
     "dockerImage": "my-docker-repo/{{name}}",

--- a/npm-js/create-kalix-entity/template/base-ts/package.json
+++ b/npm-js/create-kalix-entity/template/base-ts/package.json
@@ -15,11 +15,9 @@
     "@types/mocha": "^9.1.1",
     "@types/node": "18.0.0",
     "chai": "^4.3.6",
-    "jsdoc": "^3.6.10",
     "mocha": "^10.0.0",
     "ts-mocha": "^10.0.0",
-    "typescript": "^4.7.4",
-    "uglify-js": "^3.16.1"
+    "typescript": "^4.7.4"
   },
   "config": {
     "typescript": true,


### PR DESCRIPTION
Not sure why `jsdoc` and `uglify-js` were listed as dependencies in the templates, but shouldn't be needed as explicit dependencies.