### PR TITLE
fix: Docker cross build not installed unless explicitly '--load'ed 

### DIFF
--- a/npm-js/kalix-scripts/bin/kalix-scripts.js
+++ b/npm-js/kalix-scripts/bin/kalix-scripts.js
@@ -17,7 +17,7 @@ const kalixScriptDir = path.resolve(__dirname, '..');
 
 const dockerBuildArgs =
   process.arch === 'arm64'
-    ? ['buildx', 'build', '--platform=linux/amd64']
+    ? ['buildx', 'build', '--platform=linux/amd64', '--load']
     : ['build'];
 
 const dockerBuild = (dockerTag) =>


### PR DESCRIPTION
References #99

Follow up to #365 