### PR TITLE
chore: remove version update from release template

### DIFF
--- a/.github/release-issue-template.md
+++ b/.github/release-issue-template.md
@@ -19,7 +19,6 @@ You can see the proxy version on prod [on grafana](https://lightbendcloud.grafan
 
 ### Fix and publish docs
 
-- [ ] Update the [latest version in the main docs](https://github.com/lightbend/kalix-docs/blob/main/docs/modules/ROOT/partials/include.adoc#L21)
 - [ ] If relevant, update the [supported version in the main docs](https://github.com/lightbend/kalix-docs/blob/main/docs/modules/ROOT/partials/include.adoc#L20) (affects [Supported Versions](https://docs.kalix.io/setting-up/index.html#_supported_languages))
 - [ ] Add an item to the [Release Notes](https://github.com/lightbend/kalix-docs/blob/main/docs/modules/release-notes/pages/index.adoc) in the documentation
 - [ ] Release the Kalix documentation to get the SDK docs updates published


### PR DESCRIPTION
Not needed now. Latest version provided by the SDK docs and updated automatically on publish.