### PR TITLE
chore: avoiding calling through the mesh to same services components

### DIFF
--- a/sdk/src/kalix.ts
+++ b/sdk/src/kalix.ts
@@ -717,7 +717,7 @@ export class Kalix {
         proxyHostname:
           proxyInfo.internalProxyHostname ?? proxyInfo.proxyHostname,
         proxyPort:
-          proxyInfo.proxyPort ??
+          this.proxyPort ??
           (proxyInfo.proxyHostname == 'localhost' ? 9000 : 80),
         identificationInfo: proxyInfo.identificationInfo || undefined,
       };

--- a/sdk/src/kalix.ts
+++ b/sdk/src/kalix.ts
@@ -698,10 +698,11 @@ export class Kalix {
       this.proxyHasTerminated = false;
 
       console.log(
-        'Received discovery call from [%s %s] at [%s] supporting Kalix protocol %s.%s',
+        'Received discovery call from [%s %s] at [%s]:[%s] supporting Kalix protocol %s.%s',
         proxyInfo.proxyName,
         proxyInfo.proxyVersion,
-        proxyInfo.proxyHostname,
+        proxyInfo.internalProxyHostname,
+        proxyInfo.proxyPort,
         proxyInfo.protocolMajorVersion,
         proxyInfo.protocolMinorVersion,
       );
@@ -711,11 +712,12 @@ export class Kalix {
         proxyInfo,
         this.components.length,
       );
-
+      // references to proxyHostname are for backward compatibility with proxy 1.0.14 and older
       const preStartSettings: PreStartSettings = {
-        proxyHostname: proxyInfo.proxyHostname,
+        proxyHostname:
+          proxyInfo.internalProxyHostname ?? proxyInfo.proxyHostname,
         proxyPort:
-          this.proxyPort ??
+          proxyInfo.proxyPort ??
           (proxyInfo.proxyHostname == 'localhost' ? 9000 : 80),
         identificationInfo: proxyInfo.identificationInfo || undefined,
       };


### PR DESCRIPTION
References https://github.com/lightbend/kalix-proxy/issues/1469 and depends on https://github.com/lightbend/kalix-proxy/pull/1599