### PR TITLE
ci: update machine images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,7 +179,7 @@ jobs:
 
   tests:
     machine:
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2004:2022.07.1
     description: "tests"
     steps:
       - checkout-and-merge-to-main
@@ -394,7 +394,7 @@ jobs:
 
   integration-tests:
     machine:
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2004:2022.07.1
     description: "integration tests"
     steps:
       - checkout-and-merge-to-main
@@ -662,7 +662,7 @@ jobs:
 
   tck-tests:
     machine:
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2004:2022.07.1
     description: "TCK tests"
     steps:
       - checkout-and-merge-to-main
@@ -675,7 +675,7 @@ jobs:
 
   validate-docs:
     machine:
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2004:2022.07.1
     description: "validate docs"
     steps:
       - checkout-and-merge-to-main
@@ -718,7 +718,7 @@ jobs:
 
   publish-tck:
     machine:
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2004:2022.07.1
     description: "publish TCK"
     steps:
       - checkout
@@ -731,7 +731,7 @@ jobs:
 
   publish-docs:
     machine:
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2004:2022.07.1
     description: "publish docs"
     steps:
       - checkout
@@ -836,7 +836,7 @@ jobs:
 
   e2e-tests:
     machine:
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2004:2022.07.1
     description: "e2e-tests"
     steps:
       - checkout-and-merge-to-main
@@ -919,7 +919,7 @@ jobs:
 
   publish_native_linux:
     machine:
-      image: ubuntu-2204:2022.04.2
+      image: ubuntu-2004:2022.07.1
     description: "Build Native image on Linux"
     steps:
       - checkout
@@ -940,7 +940,7 @@ jobs:
 
   publish_native_macos:
     macos:
-      xcode: 12.5.0
+      xcode: 12.5.1
     description: "Build Native image on macOS"
     steps:
       - checkout


### PR DESCRIPTION
* downgrade ubuntu images from 22.04 to latest 20.04
* upgrade macos image to 12.5.1

Fixes following the 1.0.1 release (#402).

Codegen binary for linux was built against a newer glibc (building with ubuntu 22.04) than in the docker image (debian 10). The Debian 11 (node bullseye) images are still on older glibc as well. To keep things simple, downgrade the machine images to ubuntu 20.04 again, but should still be with a new enough docker version (the reason they were bumped originally, #391).

The 1.0.1 release failed to build the macOS codegen binary, as 12.5.0 image was not available. Bump to available 12.5.1.

I'll manually confirm a couple of things in the test build.

Would be useful to have some tests that build these, and check across platforms, but for another time...