### PR TITLE
chore: upgrade kalix proxy version to 1.0.16

### DIFF
--- a/codegen/js-gen-cli/src/it/resources/application.conf
+++ b/codegen/js-gen-cli/src/it/resources/application.conf
@@ -4,5 +4,5 @@ kalix-npm-js {
 }
 
 kalix-proxy {
-    image = "gcr.io/kalix-public/kalix-proxy:1.0.15"
+    image = "gcr.io/kalix-public/kalix-proxy:1.0.16"
 }

--- a/npm-js/create-kalix-entity/template/base-common/docker-compose.yml
+++ b/npm-js/create-kalix-entity/template/base-common/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -kalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/js/js-customer-registry-quickstart/docker-compose.yml
+++ b/samples/js/js-customer-registry-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -kalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/js/js-doc-snippets/docker-compose.yml
+++ b/samples/js/js-doc-snippets/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/js/js-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/js/js-eventsourced-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/js/js-replicated-entity-shopping-cart/docker-compose.yml
+++ b/samples/js/js-replicated-entity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/js/js-shopping-cart-quickstart/docker-compose.yml
+++ b/samples/js/js-shopping-cart-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -kalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/js/js-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/js/js-valueentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/js/valueentity-counter/docker-compose.yml
+++ b/samples/js/valueentity-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/ts/ts-customer-registry-quickstart/docker-compose.yml
+++ b/samples/ts/ts-customer-registry-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -kalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/ts/ts-eventsourced-shopping-cart/docker-compose.yml
+++ b/samples/ts/ts-eventsourced-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/ts/ts-replicated-entity-shopping-cart/docker-compose.yml
+++ b/samples/ts/ts-replicated-entity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/ts/ts-shopping-cart-quickstart/docker-compose.yml
+++ b/samples/ts/ts-shopping-cart-quickstart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -kalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/ts/ts-valueentity-counter/docker-compose.yml
+++ b/samples/ts/ts-valueentity-counter/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/samples/ts/ts-valueentity-shopping-cart/docker-compose.yml
+++ b/samples/ts/ts-valueentity-shopping-cart/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   kalix-proxy:
-    image: gcr.io/kalix-public/kalix-proxy:1.0.15
+    image: gcr.io/kalix-public/kalix-proxy:1.0.16
     command: -Dconfig.resource=dev-mode.conf -Dkalix.proxy.eventing.support=google-pubsub-emulator
     ports:
       - "9000:9000"

--- a/sdk/config.json
+++ b/sdk/config.json
@@ -1,3 +1,3 @@
 {
-  "frameworkVersion": "1.0.15"
+  "frameworkVersion": "1.0.16"
 }


### PR DESCRIPTION
References [Proxy 1.0.16](https://github.com/lightbend/kalix-proxy/issues/1611)