### PR TITLE
fix: allow updated type dependency for node

### DIFF
--- a/npm-js/create-kalix-entity/template/base-ts/package.json
+++ b/npm-js/create-kalix-entity/template/base-ts/package.json
@@ -13,7 +13,7 @@
     "@kalix-io/testkit": "{{testkitVersion}}",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "^18.0.0",
     "chai": "^4.3.6",
     "mocha": "^10.0.0",
     "ts-mocha": "^10.0.0",

--- a/samples/ts/ts-customer-registry-quickstart/package.json
+++ b/samples/ts/ts-customer-registry-quickstart/package.json
@@ -13,7 +13,7 @@
     "@kalix-io/testkit": "^1.0.6",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "^18.0.0",
     "chai": "^4.3.6",
     "mocha": "^10.0.0",
     "ts-mocha": "^10.0.0",

--- a/samples/ts/ts-customer-registry/package.json
+++ b/samples/ts/ts-customer-registry/package.json
@@ -30,7 +30,7 @@
     "@kalix-io/testkit": "1.0.6",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "chai": "^4.3.6",

--- a/samples/ts/ts-eventsourced-shopping-cart/package.json
+++ b/samples/ts/ts-eventsourced-shopping-cart/package.json
@@ -13,7 +13,7 @@
     "@kalix-io/kalix-scripts": "1.0.6",
     "@kalix-io/testkit": "1.0.6",
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "chai": "^4.3.6",

--- a/samples/ts/ts-replicated-entity-example/package.json
+++ b/samples/ts/ts-replicated-entity-example/package.json
@@ -29,7 +29,7 @@
     "@kalix-io/kalix-scripts": "1.0.6",
     "@kalix-io/testkit": "1.0.6",
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "chai": "^4.3.6",

--- a/samples/ts/ts-replicated-entity-shopping-cart/package.json
+++ b/samples/ts/ts-replicated-entity-shopping-cart/package.json
@@ -15,7 +15,7 @@
     "@types/chai": "^4.3.1",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "chai": "^4.3.6",

--- a/samples/ts/ts-shopping-cart-quickstart/package.json
+++ b/samples/ts/ts-shopping-cart-quickstart/package.json
@@ -13,7 +13,7 @@
     "@kalix-io/testkit": "^1.0.6",
     "@types/chai": "^4.3.1",
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "^18.0.0",
     "chai": "^4.3.6",
     "mocha": "^10.0.0",
     "ts-mocha": "^10.0.0",

--- a/samples/ts/ts-valueentity-counter/package.json
+++ b/samples/ts/ts-valueentity-counter/package.json
@@ -13,7 +13,7 @@
     "@kalix-io/kalix-scripts": "1.0.6",
     "@kalix-io/testkit": "1.0.6",
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "chai": "^4.3.6",

--- a/samples/ts/ts-valueentity-shopping-cart/package.json
+++ b/samples/ts/ts-valueentity-shopping-cart/package.json
@@ -13,7 +13,7 @@
     "@kalix-io/kalix-scripts": "1.0.6",
     "@kalix-io/testkit": "1.0.6",
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "chai": "^4.3.6",

--- a/samples/ts/ts-views-example/package.json
+++ b/samples/ts/ts-views-example/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@types/mocha": "^9.1.1",
-    "@types/node": "18.0.0",
+    "@types/node": "^18.0.0",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
     "chai": "4.3.6",


### PR DESCRIPTION
Looking to fix the typescript issue as seen in #437 by allowing an updated `@types/node` dependency.