### PR TITLE
docs: add grpc common ACL docs to sdk specific page

### DIFF
--- a/docs/dev/src/modules/ROOT/partials/grpc/using-acls.adoc
+++ b/docs/dev/src/modules/ROOT/partials/grpc/using-acls.adoc
@@ -1,0 +1,2 @@
+// this is just a placeholder so we can compile sdk docs here
+// the real file can be found in kalix-docs repo

--- a/docs/src/modules/javascript/pages/access-control.adoc
+++ b/docs/src/modules/javascript/pages/access-control.adoc
@@ -1,6 +1,8 @@
 = Access Control Lists (ACLs)
 
-This section describes functionality in the JavaScript/TypeScript SDK related to ACLs (Access Control Lists), for information about how the ACLs are defined and control access see https://docs.kalix.io/services/using-acls.html[Using ACLs].
+This section describes the practical aspects of configuring Access Control Lists (ACLs) with the JavaScript/TypeScript SDKs, if you are not sure what ACLs are or how they work, see https://docs.kalix.io/security/acls.html[Understanding ACLs] first.
+
+include::ROOT:partial$grpc/using-acls.adoc[]
 
 == Default ACL in project templates
 


### PR DESCRIPTION
References https://github.com/lightbend/kalix-docs/issues/1665

Dependent on https://github.com/lightbend/kalix-docs/pull/1670 