### PR TITLE
fix: Catch and continue discovery if component.preStart fails

### DIFF
--- a/sdk/src/kalix.ts
+++ b/sdk/src/kalix.ts
@@ -747,8 +747,15 @@ export class Kalix {
       };
 
       const components = this.components.map((component) => {
-        component.preStart(preStartSettings);
-
+        try {
+          component.preStart(preStartSettings);
+        } catch (e) {
+          console.log(
+            'Could not invoke a preStart method on %s, cross component calls may not work. Error: %s',
+            component.serviceName,
+            e,
+          );
+        }
         const res: discovery.Component = {
           serviceName: component.serviceName,
           componentType: component.componentType(),


### PR DESCRIPTION
For example if it is not defined, or overloaded with broken logic.

References lightbend/kalix-proxy#1570