### PR TITLE
chore: Report ts and js as separate SDKs #389

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -7,6 +7,7 @@ sources  := src build/src/managed
 
 src_managed := build/src/managed
 managed_attachments := ${src_managed}/modules/${module}/attachments
+managed_ts_attachments := ${src_managed}/modules/typescript/attachments
 managed_examples := ${src_managed}/modules/${module}/examples
 managed_partials := ${src_managed}/modules/${module}/partials
 
@@ -38,8 +39,10 @@ attributes:
 apidocs:
 	cd ../sdk && npm ci && npm run typedoc
 	mkdir -p "${managed_attachments}"
+	mkdir -p "${managed_ts_attachments}"
 	rsync -a ../sdk/apidocs/ "${managed_attachments}/api/"
 	bin/version.sh > "${managed_attachments}/latest-version.txt"
+	cp "${managed_attachments}/latest-version.txt" "${managed_ts_attachments}/latest-version.txt"
 
 examples:
 	mkdir -p "${managed_examples}"

--- a/sdk/src/kalix.ts
+++ b/sdk/src/kalix.ts
@@ -90,7 +90,12 @@ class ServiceInfo {
 
   private loadFromPkg(filename: string = userPkgJson) {
     const json = loadJson(filename);
-    this.pkgName = json.name;
+    // try to detect if ts or js through process starting points
+    if (process.argv.find((arg: string) => arg.endsWith('.ts'))) {
+      this.pkgName = json.name.replace('javascript', 'typescript');
+    } else {
+      this.pkgName = json.name;
+    }
     this.pkgVersion = json.version;
   }
 }


### PR DESCRIPTION
References #389

Depends on upstream support for the typescript name in the proxy that must be in production before this can be merged/released.