### PR TITLE
fix: hide todos from published docs

### DIFF
--- a/docs/dev/antora.yml
+++ b/docs/dev/antora.yml
@@ -17,8 +17,6 @@ runtime:
 
 asciidoc:
   attributes:
-    review: ''
-    todo: ''
     page-pagination: ''
     page-toctitle: 'On This Page'
 


### PR DESCRIPTION
<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please reference them here.
-->
Same as https://github.com/lightbend/kalix-jvm-sdk/pull/1625