### PR TITLE
bump: update node base image in Dockerfiles to 18-bookworm-slim

### DIFF
--- a/npm-js/create-kalix-entity/template/base-js/Dockerfile
+++ b/npm-js/create-kalix-entity/template/base-js/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/npm-js/create-kalix-entity/template/base-ts/Dockerfile
+++ b/npm-js/create-kalix-entity/template/base-ts/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-customer-registry-quickstart/Dockerfile
+++ b/samples/js/js-customer-registry-quickstart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-customer-registry/Dockerfile
+++ b/samples/js/js-customer-registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY sdk sdk
@@ -10,7 +10,7 @@ COPY samples/js/js-customer-registry samples/js/js-customer-registry
 RUN cd samples/js/js-customer-registry && npm run build
 RUN cd samples/js/js-customer-registry && npm prune --production
 
-FROM node:14-buster-slim
+FROM node:18-bookworm-slim
 COPY --from=builder --chown=node /home/node /home/node
 WORKDIR /home/node/samples/js/js-customer-registry
 USER node

--- a/samples/js/js-doc-snippets/Dockerfile
+++ b/samples/js/js-doc-snippets/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-eventsourced-shopping-cart/Dockerfile
+++ b/samples/js/js-eventsourced-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-replicated-entity-example/Dockerfile
+++ b/samples/js/js-replicated-entity-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY sdk sdk
@@ -10,7 +10,7 @@ COPY samples/js/js-replicated-entity-example samples/js/js-replicated-entity-exa
 RUN cd samples/js/js-replicated-entity-example && npm run build
 RUN cd samples/js/js-replicated-entity-example && npm prune --production
 
-FROM node:14-buster-slim
+FROM node:18-bookworm-slim
 COPY --from=builder --chown=node /home/node /home/node
 WORKDIR /home/node/samples/js/js-replicated-entity-example
 USER node

--- a/samples/js/js-replicated-entity-shopping-cart/Dockerfile
+++ b/samples/js/js-replicated-entity-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-shopping-cart-quickstart/Dockerfile
+++ b/samples/js/js-shopping-cart-quickstart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-valueentity-shopping-cart/Dockerfile
+++ b/samples/js/js-valueentity-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/js/js-views-example/Dockerfile
+++ b/samples/js/js-views-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY sdk sdk
@@ -10,7 +10,7 @@ COPY samples/js/js-views-example samples/js/js-views-example
 RUN cd samples/js/js-views-example && npm run build
 RUN cd samples/js/js-views-example && npm prune --production
 
-FROM node:14-buster-slim
+FROM node:18-bookworm-slim
 COPY --from=builder --chown=node /home/node /home/node
 WORKDIR /home/node/samples/js/js-views-example
 USER node

--- a/samples/js/valueentity-counter/Dockerfile
+++ b/samples/js/valueentity-counter/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-customer-registry-quickstart/Dockerfile
+++ b/samples/ts/ts-customer-registry-quickstart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-customer-registry/Dockerfile
+++ b/samples/ts/ts-customer-registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY samples/ts/ts-customer-registry/package*.json samples/ts/ts-customer-registry/
@@ -7,7 +7,7 @@ COPY samples/ts/ts-customer-registry samples/ts/ts-customer-registry
 RUN cd samples/ts/ts-customer-registry && npm run build
 RUN cd samples/ts/ts-customer-registry && npm prune --production
 
-FROM node:14-buster-slim
+FROM node:18-bookworm-slim
 COPY --from=builder --chown=node /home/node /home/node
 WORKDIR /home/node/samples/ts/ts-customer-registry
 USER node

--- a/samples/ts/ts-eventsourced-shopping-cart/Dockerfile
+++ b/samples/ts/ts-eventsourced-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-replicated-entity-example/Dockerfile
+++ b/samples/ts/ts-replicated-entity-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY samples/ts/ts-replicated-entity-example/package*.json samples/ts/ts-replicated-entity-example/
@@ -7,7 +7,7 @@ COPY samples/ts/ts-replicated-entity-example samples/ts/ts-replicated-entity-exa
 RUN cd samples/ts/ts-replicated-entity-example && npm run build
 RUN cd samples/ts/ts-replicated-entity-example && npm prune --production
 
-FROM node:14-buster-slim
+FROM node:18-bookworm-slim
 COPY --from=builder --chown=node /home/node /home/node
 WORKDIR /home/node/samples/ts/ts-replicated-entity-example
 USER node

--- a/samples/ts/ts-replicated-entity-shopping-cart/Dockerfile
+++ b/samples/ts/ts-replicated-entity-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-shopping-cart-quickstart/Dockerfile
+++ b/samples/ts/ts-shopping-cart-quickstart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-valueentity-counter/Dockerfile
+++ b/samples/ts/ts-valueentity-counter/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-valueentity-shopping-cart/Dockerfile
+++ b/samples/ts/ts-valueentity-shopping-cart/Dockerfile
@@ -2,7 +2,7 @@
 # See https://docs.docker.com/develop/develop-images/multistage-build/
 
 # Stage 1: Downloading dependencies and building the application
-FROM node:14.19-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 
 RUN apt-get update && apt-get install -y python3 make g++ && rm -rf /var/lib/apt/lists/*
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN npm prune --production
 
 # Stage 2: Building the production image
-FROM node:14.19-buster-slim
+FROM node:18-bookworm-slim
 
 # Set the working directory
 WORKDIR /home/node

--- a/samples/ts/ts-views-example/Dockerfile
+++ b/samples/ts/ts-views-example/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 WORKDIR /home/node
 RUN apt-get update && apt-get install -y curl unzip
 COPY samples/ts/ts-views-example/package*.json samples/ts/ts-views-example/
@@ -7,7 +7,7 @@ COPY samples/ts/ts-views-example samples/ts/ts-views-example
 RUN cd samples/ts/ts-views-example && npm run build
 RUN cd samples/ts/ts-views-example && npm prune --production
 
-FROM node:14-buster-slim
+FROM node:18-bookworm-slim
 COPY --from=builder --chown=node /home/node /home/node
 WORKDIR /home/node/samples/ts/ts-views-example
 USER node

--- a/tck/Dockerfile
+++ b/tck/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-buster-slim AS builder
+FROM node:18-bookworm-slim AS builder
 RUN apt-get update && apt-get install -y curl unzip
 WORKDIR /home/node
 USER node
@@ -12,7 +12,7 @@ COPY --chown=node tck tck
 RUN cd tck && npm run build
 RUN cd tck && npm prune --production
 
-FROM node:14-buster-slim
+FROM node:18-bookworm-slim
 COPY --from=builder --chown=node /home/node /home/node
 WORKDIR /home/node/tck
 USER node


### PR DESCRIPTION
Bumping the dockerfiles to node 18 was missed in #459. Drop the minor version to keep maintaining this simple.

Also bump the debian version from debian 10 (buster) to current stable debian 12 (bookworm). This is required, as the CI images were updated to ubuntu 22.04 in #434, and the published codegen native images now require a newer glibc. See #406 for when this was downgraded again for this reason. We could also switch the codegen native image builds for linux to static binaries to avoid this issue on dynamically linking libc.