### PR TITLE
ci: upgrade resources for npm-js-tests to large for native image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -760,6 +760,7 @@ jobs:
   npm-js-tests:
     docker:
       - image: cimg/node:18.16.0
+    resource_class: large
     description: "npm-js-tests"
     steps:
       - checkout-and-merge-to-main


### PR DESCRIPTION
We sometimes see the native image build fail with out-of-memory for `npm-js-tests`. For successful builds it's reaching 97% memory usage, and can sometimes go over the limit. The default resource class is 4 GB. Upgrade to the `large` resource class with 8 GB.