### PR TITLE
ci: bump macos resource class to medium gen2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -953,6 +953,7 @@ jobs:
   publish_native_macos:
     macos:
       xcode: 13.4.1
+    resource_class: macos.x86.medium.gen2
     description: "Build Native image on macOS"
     steps:
       - checkout


### PR DESCRIPTION
Refs #511. Bump to `macos.x86.medium.gen2`, as default `medium` class will be deprecated on 2 October.